### PR TITLE
feat(worker): implement CF Worker routes with Plaid + Splitwise proxies

### DIFF
--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+interface Env {
+  PLAID_CLIENT_ID: string;
+  PLAID_SECRET: string;
+  PLAID_ENV: string;
+  WORKER_API_KEY: string;
+  SPLITWISE_CLIENT_ID: string;
+  SPLITWISE_CLIENT_SECRET: string;
+}
+
+const makeEnv = (overrides: Partial<Env> = {}): Env => ({
+  PLAID_CLIENT_ID: 'test_client_id',
+  PLAID_SECRET: 'test_secret',
+  PLAID_ENV: 'sandbox',
+  WORKER_API_KEY: 'test_api_key',
+  SPLITWISE_CLIENT_ID: 'sw_client_id',
+  SPLITWISE_CLIENT_SECRET: 'sw_secret',
+  ...overrides,
+});
+
+// Import handler at module level (vitest handles mock hoisting)
+import handler from './index';
+
+beforeEach(() => { mockFetch.mockReset(); });
+
+describe('Worker auth middleware', () => {
+  it('returns 401 when Authorization header is missing', async () => {
+    const req = new Request('https://worker.example.com/plaid/link-token', { method: 'POST' });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when API key is wrong', async () => {
+    const req = new Request('https://worker.example.com/plaid/link-token', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer wrong_key' },
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /plaid/link-token', () => {
+  it('returns link_token on success', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ link_token: 'link-sandbox-abc' }), { status: 200 })
+    );
+    const req = new Request('https://worker.example.com/plaid/link-token', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key' },
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { link_token: string };
+    expect(body.link_token).toBe('link-sandbox-abc');
+  });
+
+  it('uses correct plaid base URL for sandbox vs production', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ link_token: 'link-prod-abc' }), { status: 200 })
+    );
+    const req = new Request('https://worker.example.com/plaid/link-token', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key' },
+    });
+    await handler.fetch(req, makeEnv({ PLAID_ENV: 'production' }), {} as ExecutionContext);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('production.plaid.com'),
+      expect.anything()
+    );
+  });
+});
+
+describe('POST /plaid/exchange', () => {
+  it('returns access_token on success', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: 'access-sandbox-xyz', item_id: 'item1' }), { status: 200 })
+    );
+    const req = new Request('https://worker.example.com/plaid/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ public_token: 'public-sandbox-token' }),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { access_token: string };
+    expect(body.access_token).toBe('access-sandbox-xyz');
+  });
+});
+
+describe('POST /plaid/transactions', () => {
+  it('strips credits (amount <= 0) from added and modified', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        added: [
+          { transaction_id: 'tx1', amount: 25.00, merchant_name: 'Coffee' },
+          { transaction_id: 'tx2', amount: -10.00, merchant_name: 'Refund' },
+        ],
+        modified: [],
+        removed: [],
+        next_cursor: 'cursor-abc',
+        has_more: false,
+      }), { status: 200 })
+    );
+    const req = new Request('https://worker.example.com/plaid/transactions', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ access_token: 'access-sandbox-xyz' }),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { added: { transaction_id: string }[] };
+    expect(body.added).toHaveLength(1);
+    expect(body.added[0].transaction_id).toBe('tx1');
+  });
+
+  it('returns 400 with ITEM_LOGIN_REQUIRED error', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error_code: 'ITEM_LOGIN_REQUIRED' }), { status: 400 })
+    );
+    const req = new Request('https://worker.example.com/plaid/transactions', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ access_token: 'access-sandbox-xyz' }),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('ITEM_LOGIN_REQUIRED');
+  });
+});
+
+describe('POST /splitwise/exchange', () => {
+  it('returns access_token and user profile', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: 'sw-token-abc' }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          user: { id: 123, first_name: 'Bala', last_name: 'K', picture: { medium: 'https://img.url' } }
+        }), { status: 200 })
+      );
+    const req = new Request('https://worker.example.com/splitwise/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'auth-code-123', redirect_uri: 'spliteasy://oauth' }),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(200);
+    // user_id is returned as a string (Worker converts Splitwise int ID to string)
+    const body = await res.json() as { access_token: string; user_id: string; display_name: string };
+    expect(body.access_token).toBe('sw-token-abc');
+    expect(body.user_id).toBe('123');         // string, not number
+    expect(body.display_name).toBe('Bala K');
+  });
+});

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -1,16 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler, { type Env } from './index';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
-
-interface Env {
-  PLAID_CLIENT_ID: string;
-  PLAID_SECRET: string;
-  PLAID_ENV: string;
-  WORKER_API_KEY: string;
-  SPLITWISE_CLIENT_ID: string;
-  SPLITWISE_CLIENT_SECRET: string;
-}
 
 const makeEnv = (overrides: Partial<Env> = {}): Env => ({
   PLAID_CLIENT_ID: 'test_client_id',
@@ -21,9 +13,6 @@ const makeEnv = (overrides: Partial<Env> = {}): Env => ({
   SPLITWISE_CLIENT_SECRET: 'sw_secret',
   ...overrides,
 });
-
-// Import handler at module level (vitest handles mock hoisting)
-import handler from './index';
 
 beforeEach(() => { mockFetch.mockReset(); });
 
@@ -90,10 +79,25 @@ describe('POST /plaid/exchange', () => {
     const body = await res.json() as { access_token: string };
     expect(body.access_token).toBe('access-sandbox-xyz');
   });
+
+  it('returns error when Plaid rejects the public_token', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error_code: 'INVALID_PUBLIC_TOKEN' }), { status: 400 })
+    );
+    const req = new Request('https://worker.example.com/plaid/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ public_token: 'bad-token' }),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('INVALID_PUBLIC_TOKEN');
+  });
 });
 
 describe('POST /plaid/transactions', () => {
-  it('strips credits (amount <= 0) from added and modified', async () => {
+  it('strips credits (amount <= 0) from added', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({
         added: [
@@ -118,6 +122,31 @@ describe('POST /plaid/transactions', () => {
     expect(body.added[0].transaction_id).toBe('tx1');
   });
 
+  it('strips credits (amount <= 0) from modified', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        added: [],
+        modified: [
+          { transaction_id: 'tx3', amount: 15.00, merchant_name: 'Lunch' },
+          { transaction_id: 'tx4', amount: 0.00, merchant_name: 'Zero' },
+        ],
+        removed: [],
+        next_cursor: 'cursor-xyz',
+        has_more: false,
+      }), { status: 200 })
+    );
+    const req = new Request('https://worker.example.com/plaid/transactions', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ access_token: 'access-sandbox-xyz' }),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { modified: { transaction_id: string }[] };
+    expect(body.modified).toHaveLength(1);
+    expect(body.modified[0].transaction_id).toBe('tx3');
+  });
+
   it('returns 400 with ITEM_LOGIN_REQUIRED error', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ error_code: 'ITEM_LOGIN_REQUIRED' }), { status: 400 })
@@ -131,6 +160,18 @@ describe('POST /plaid/transactions', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toBe('ITEM_LOGIN_REQUIRED');
+  });
+
+  it('returns 400 when access_token is missing', async () => {
+    const req = new Request('https://worker.example.com/plaid/transactions', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('MISSING_ACCESS_TOKEN');
   });
 });
 
@@ -157,5 +198,39 @@ describe('POST /splitwise/exchange', () => {
     expect(body.access_token).toBe('sw-token-abc');
     expect(body.user_id).toBe('123');         // string, not number
     expect(body.display_name).toBe('Bala K');
+  });
+
+  it('returns 400 when Splitwise token endpoint returns an error', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 })
+    );
+    const req = new Request('https://worker.example.com/splitwise/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'bad-code', redirect_uri: 'spliteasy://oauth' }),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('invalid_grant');
+  });
+
+  it('returns 502 when get_current_user fails after successful token exchange', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: 'sw-token-abc' }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+      );
+    const req = new Request('https://worker.example.com/splitwise/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'auth-code-123', redirect_uri: 'spliteasy://oauth' }),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(502);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('SPLITWISE_PROFILE_ERROR');
   });
 });

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -64,6 +64,28 @@ describe('POST /plaid/link-token', () => {
   });
 });
 
+describe('Route matching', () => {
+  it('returns 404 for unknown route', async () => {
+    const req = new Request('https://worker.example.com/foo', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer test_api_key' },
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('Not Found');
+  });
+
+  it('returns 404 for non-POST method on valid path', async () => {
+    const req = new Request('https://worker.example.com/plaid/link-token', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer test_api_key' },
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(404);
+  });
+});
+
 describe('POST /plaid/exchange', () => {
   it('returns access_token on success', async () => {
     mockFetch.mockResolvedValueOnce(
@@ -78,6 +100,30 @@ describe('POST /plaid/exchange', () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { access_token: string };
     expect(body.access_token).toBe('access-sandbox-xyz');
+  });
+
+  it('returns 400 when public_token is missing', async () => {
+    const req = new Request('https://worker.example.com/plaid/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('MISSING_PUBLIC_TOKEN');
+  });
+
+  it('returns 400 when request body is malformed JSON', async () => {
+    const req = new Request('https://worker.example.com/plaid/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('INVALID_REQUEST_BODY');
   });
 
   it('returns error when Plaid rejects the public_token', async () => {
@@ -162,6 +208,18 @@ describe('POST /plaid/transactions', () => {
     expect(body.error).toBe('ITEM_LOGIN_REQUIRED');
   });
 
+  it('returns 400 when request body is malformed JSON', async () => {
+    const req = new Request('https://worker.example.com/plaid/transactions', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('INVALID_REQUEST_BODY');
+  });
+
   it('returns 400 when access_token is missing', async () => {
     const req = new Request('https://worker.example.com/plaid/transactions', {
       method: 'POST',
@@ -213,6 +271,42 @@ describe('POST /splitwise/exchange', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toBe('invalid_grant');
+  });
+
+  it('returns 400 when code is missing', async () => {
+    const req = new Request('https://worker.example.com/splitwise/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ redirect_uri: 'spliteasy://oauth' }),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('MISSING_REQUIRED_PARAMS');
+  });
+
+  it('returns 400 when redirect_uri is missing', async () => {
+    const req = new Request('https://worker.example.com/splitwise/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'auth-code-123' }),
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('MISSING_REQUIRED_PARAMS');
+  });
+
+  it('returns 400 when request body is malformed JSON', async () => {
+    const req = new Request('https://worker.example.com/splitwise/exchange', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test_api_key', 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+    const res = await handler.fetch(req, makeEnv(), {} as ExecutionContext);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('INVALID_REQUEST_BODY');
   });
 
   it('returns 502 when get_current_user fails after successful token exchange', async () => {

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -47,7 +47,10 @@ async function handleLinkToken(env: Env): Promise<Response> {
 }
 
 async function handleExchange(req: Request, env: Env): Promise<Response> {
-  const { public_token } = await req.json() as { public_token: string };
+  const { public_token } = await req.json() as { public_token?: string };
+  if (!public_token || typeof public_token !== 'string') {
+    return json({ error: 'MISSING_PUBLIC_TOKEN' }, 400);
+  }
   const res = await fetch(`${plaidBase(env)}/item/public_token/exchange`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -108,7 +111,10 @@ async function handleTransactions(req: Request, env: Env): Promise<Response> {
 }
 
 async function handleSplitwiseExchange(req: Request, env: Env): Promise<Response> {
-  const { code, redirect_uri } = await req.json() as { code: string; redirect_uri: string };
+  const { code, redirect_uri } = await req.json() as { code?: string; redirect_uri?: string };
+  if (!code || typeof code !== 'string' || !redirect_uri || typeof redirect_uri !== 'string') {
+    return json({ error: 'MISSING_REQUIRED_PARAMS' }, 400);
+  }
   const tokenRes = await fetch('https://secure.splitwise.com/oauth/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -142,12 +148,19 @@ async function handleSplitwiseExchange(req: Request, env: Env): Promise<Response
 
 export default {
   async fetch(req: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
-    if (!authenticate(req, env)) return json({ error: 'Unauthorized' }, 401);
-    const path = new URL(req.url).pathname;
-    if (req.method === 'POST' && path === '/plaid/link-token') return handleLinkToken(env);
-    if (req.method === 'POST' && path === '/plaid/exchange') return handleExchange(req, env);
-    if (req.method === 'POST' && path === '/plaid/transactions') return handleTransactions(req, env);
-    if (req.method === 'POST' && path === '/splitwise/exchange') return handleSplitwiseExchange(req, env);
-    return json({ error: 'Not Found' }, 404);
+    try {
+      if (!authenticate(req, env)) return json({ error: 'Unauthorized' }, 401);
+      const path = new URL(req.url).pathname;
+      if (req.method === 'POST' && path === '/plaid/link-token') return handleLinkToken(env);
+      if (req.method === 'POST' && path === '/plaid/exchange') return handleExchange(req, env);
+      if (req.method === 'POST' && path === '/plaid/transactions') return handleTransactions(req, env);
+      if (req.method === 'POST' && path === '/splitwise/exchange') return handleSplitwiseExchange(req, env);
+      return json({ error: 'Not Found' }, 404);
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        return json({ error: 'INVALID_REQUEST_BODY' }, 400);
+      }
+      throw err;
+    }
   },
 };

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -1,5 +1,153 @@
+export interface Env {
+  PLAID_CLIENT_ID: string;
+  PLAID_SECRET: string;
+  PLAID_ENV: string;
+  WORKER_API_KEY: string;
+  SPLITWISE_CLIENT_ID: string;
+  SPLITWISE_CLIENT_SECRET: string;
+}
+
+function plaidBase(env: Env): string {
+  switch (env.PLAID_ENV) {
+    case 'production': return 'https://production.plaid.com';
+    case 'development': return 'https://development.plaid.com';
+    default: return 'https://sandbox.plaid.com';
+  }
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function authenticate(req: Request, env: Env): boolean {
+  const auth = req.headers.get('Authorization') ?? '';
+  return auth === `Bearer ${env.WORKER_API_KEY}`;
+}
+
+async function handleLinkToken(env: Env): Promise<Response> {
+  const res = await fetch(`${plaidBase(env)}/link/token/create`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: env.PLAID_CLIENT_ID,
+      secret: env.PLAID_SECRET,
+      client_name: 'SplitEasy',
+      country_codes: ['US'],
+      language: 'en',
+      user: { client_user_id: 'spliteasy-user' }, // TODO(phase-2): accept user_id from request body for per-user Plaid identity
+      products: ['transactions'],
+    }),
+  });
+  const data = await res.json() as { link_token?: string; error_code?: string };
+  if (!res.ok) return json({ error: data.error_code ?? 'PLAID_ERROR' }, res.status);
+  return json({ link_token: data.link_token });
+}
+
+async function handleExchange(req: Request, env: Env): Promise<Response> {
+  const { public_token } = await req.json() as { public_token: string };
+  const res = await fetch(`${plaidBase(env)}/item/public_token/exchange`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: env.PLAID_CLIENT_ID,
+      secret: env.PLAID_SECRET,
+      public_token,
+    }),
+  });
+  const data = await res.json() as { access_token?: string; error_code?: string };
+  if (!res.ok) return json({ error: data.error_code ?? 'PLAID_ERROR' }, res.status);
+  return json({ access_token: data.access_token });
+}
+
+interface PlaidTransaction {
+  transaction_id: string;
+  amount: number;
+  [key: string]: unknown;
+}
+
+async function handleTransactions(req: Request, env: Env): Promise<Response> {
+  const { access_token, cursor } = await req.json() as { access_token?: string; cursor?: string };
+  if (!access_token || typeof access_token !== 'string') {
+    return json({ error: 'MISSING_ACCESS_TOKEN' }, 400);
+  }
+  const res = await fetch(`${plaidBase(env)}/transactions/sync`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: env.PLAID_CLIENT_ID,
+      secret: env.PLAID_SECRET,
+      access_token,
+      ...(cursor ? { cursor } : {}),
+    }),
+  });
+  const data = await res.json() as {
+    added?: PlaidTransaction[];
+    modified?: PlaidTransaction[];
+    removed?: { transaction_id: string }[];
+    next_cursor?: string;
+    has_more?: boolean;
+    error_code?: string;
+  };
+  if (!res.ok) {
+    if (data.error_code === 'ITEM_LOGIN_REQUIRED') {
+      return json({ error: 'ITEM_LOGIN_REQUIRED' }, 400);
+    }
+    return json({ error: data.error_code ?? 'PLAID_ERROR' }, res.status);
+  }
+  const isDebit = (tx: PlaidTransaction) => tx.amount > 0;
+  return json({
+    added: (data.added ?? []).filter(isDebit),
+    modified: (data.modified ?? []).filter(isDebit),
+    removed: data.removed ?? [],
+    next_cursor: data.next_cursor,
+    has_more: data.has_more ?? false,
+  });
+}
+
+async function handleSplitwiseExchange(req: Request, env: Env): Promise<Response> {
+  const { code, redirect_uri } = await req.json() as { code: string; redirect_uri: string };
+  const tokenRes = await fetch('https://secure.splitwise.com/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: env.SPLITWISE_CLIENT_ID,
+      client_secret: env.SPLITWISE_CLIENT_SECRET,
+      code,
+      redirect_uri,
+    }),
+  });
+  const tokenData = await tokenRes.json() as { access_token?: string; error?: string };
+  if (!tokenRes.ok || !tokenData.access_token) {
+    return json({ error: tokenData.error ?? 'SPLITWISE_AUTH_ERROR' }, 400);
+  }
+  const userRes = await fetch('https://secure.splitwise.com/api/v3.0/get_current_user', {
+    headers: { Authorization: `Bearer ${tokenData.access_token}` },
+  });
+  if (!userRes.ok) return json({ error: 'SPLITWISE_PROFILE_ERROR' }, 502);
+  const userData = await userRes.json() as {
+    user: { id: number; first_name: string; last_name: string; picture?: { medium?: string } }
+  };
+  const { id, first_name, last_name, picture } = userData.user;
+  return json({
+    access_token: tokenData.access_token,
+    user_id: String(id),           // always returned as string
+    display_name: `${first_name} ${last_name}`.trim(),
+    avatar_url: picture?.medium ?? null,
+  });
+}
+
 export default {
-  async fetch(request: Request): Promise<Response> {
-    return new Response("OK");
+  async fetch(req: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
+    if (!authenticate(req, env)) return json({ error: 'Unauthorized' }, 401);
+    const path = new URL(req.url).pathname;
+    if (req.method === 'POST' && path === '/plaid/link-token') return handleLinkToken(env);
+    if (req.method === 'POST' && path === '/plaid/exchange') return handleExchange(req, env);
+    if (req.method === 'POST' && path === '/plaid/transactions') return handleTransactions(req, env);
+    if (req.method === 'POST' && path === '/splitwise/exchange') return handleSplitwiseExchange(req, env);
+    return json({ error: 'Not Found' }, 404);
   },
 };


### PR DESCRIPTION
## Summary

- Implements all 4 stateless Worker routes, auth-gated via `Authorization: Bearer <WORKER_API_KEY>`
- `POST /plaid/link-token` — creates Plaid link token server-side
- `POST /plaid/exchange` — exchanges public_token → access_token; proxies Plaid errors
- `POST /plaid/transactions` — proxies `transactions/sync`, filters credits (amount ≤ 0), handles `ITEM_LOGIN_REQUIRED`; validates `access_token` presence
- `POST /splitwise/exchange` — OAuth code exchange + user profile fetch; guards against profile fetch failure (502)
- 13 Vitest tests covering auth middleware, all route success + error cases, debit filter (added + modified), zero-amount boundary

Closes #12.

## Test plan

- [ ] `cd workers && npm test` — all 13 tests pass
- [ ] Auth: missing/wrong key → 401
- [ ] `/plaid/link-token`: success, production URL routing
- [ ] `/plaid/exchange`: success, Plaid error proxied (400)
- [ ] `/plaid/transactions`: debit filter on `added` + `modified`, zero-amount excluded, `ITEM_LOGIN_REQUIRED` → 400, missing `access_token` → 400
- [ ] `/splitwise/exchange`: success with user profile, token endpoint error → 400, profile fetch failure → 502

## Notes

- `client_user_id` hardcoded as `'spliteasy-user'` for Phase 1 — tracked with `// TODO(phase-2)` comment
- `compatibility_date` updated to `2026-03-01` (picked up from scaffold PR)
- Dep versions aligned with scaffold PR (`wrangler ^3.114.0`, `@cloudflare/workers-types ^4.20260317.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)