### PR TITLE
feat(mobile): complete UI/UX redesign with modern fintech design system

### DIFF
--- a/mobile/app/(auth)/bank-connect.tsx
+++ b/mobile/app/(auth)/bank-connect.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Alert, Pressable, StatusBar, StyleSheet, Text, View } from 'react-native';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import {
   create,
@@ -10,10 +10,12 @@ import {
   LinkLogLevel,
   LinkIOSPresentationStyle,
 } from 'react-native-plaid-link-sdk';
+import { Ionicons } from '@expo/vector-icons';
 import { usePlaidStore } from '@/stores/plaidStore';
 import { getLinkToken, WorkerError } from '@/lib/worker';
 import { isPlaidLinkNativeAvailable } from '@/lib/plaidLinkAvailable';
 import { useRouter } from 'expo-router';
+import { Colors, Radius, Shadow, Spacing } from '@/lib/theme';
 
 export default function BankConnectScreen() {
   const [loading, setLoading] = useState(false);
@@ -43,8 +45,8 @@ export default function BankConnectScreen() {
       Alert.alert(
         'Plaid needs a native build',
         inExpoGo
-          ? 'Expo Go does not ship the Plaid native module, so the button cannot open Link. From the mobile folder run: npx expo run:ios or npx expo run:android'
-          : 'The Plaid native module is not in this binary. Rebuild with npx expo run:ios or npx expo run:android after native dependencies are installed.',
+          ? 'Expo Go does not ship the Plaid native module. Run: npx expo run:ios'
+          : 'The Plaid native module is not in this binary. Rebuild with npx expo run:ios.',
       );
       return;
     }
@@ -53,33 +55,24 @@ export default function BankConnectScreen() {
     try {
       const { link_token } = await getLinkToken();
       await destroy().catch(() => {});
-      // Plaid RN SDK: call `open` after `create`. Relying only on `create(..., onLoad: () => open())`
-      // breaks when native never fires `onLoad`, so Link never appears.
       create({
         token: link_token,
         logLevel: LinkLogLevel.ERROR,
         noLoadingState: false,
       });
-      // Defer `open` so `create` can register with the native bridge first (avoids no-op open on some builds).
       requestAnimationFrame(() => {
         open({
           iOSPresentationStyle: LinkIOSPresentationStyle.MODAL,
-          onSuccess: (success) => {
-            void onLinkSuccess(success);
-          },
-          onExit: (exit) => {
-            onLinkExit(exit);
-          },
+          onSuccess: (success) => { void onLinkSuccess(success); },
+          onExit: (exit) => { onLinkExit(exit); },
         });
       });
     } catch (e) {
       console.error('Plaid link failed', e);
       const message =
-        e instanceof WorkerError
-          ? e.code
-          : e instanceof Error
-            ? e.message
-            : 'Could not start bank linking.';
+        e instanceof WorkerError ? e.code
+        : e instanceof Error ? e.message
+        : 'Could not start bank linking.';
       Alert.alert('Plaid unavailable', message);
     } finally {
       setLoading(false);
@@ -87,29 +80,163 @@ export default function BankConnectScreen() {
   }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Connect your bank</Text>
-      <Text style={styles.subtitle}>
-        SplitEasy uses Plaid to securely import your transactions. Nothing is stored on any server.
-      </Text>
+    <View style={styles.root}>
+      <StatusBar barStyle="light-content" backgroundColor={Colors.hero} />
 
-      <Pressable style={styles.btn} onPress={startPlaid} disabled={loading}>
-        {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.btnText}>Connect via Plaid</Text>}
-      </Pressable>
+      {/* Hero */}
+      <View style={styles.hero}>
+        <View style={styles.stepRow}>
+          <View style={[styles.stepDot, styles.stepDotDone]} />
+          <View style={styles.stepLine} />
+          <View style={[styles.stepDot, styles.stepDotActive]} />
+        </View>
+        <View style={styles.iconRing}>
+          <Ionicons name="shield-checkmark-outline" size={32} color={Colors.primary} />
+        </View>
+        <Text style={styles.title}>Connect your bank</Text>
+        <Text style={styles.subtitle}>Securely import transactions via Plaid.</Text>
+      </View>
 
-      <Pressable style={styles.skip} onPress={() => router.replace('/(tabs)/')}>
-        <Text style={styles.skipText}>Skip for now</Text>
-      </Pressable>
+      {/* Card */}
+      <View style={styles.card}>
+        <SecurityItem icon="lock-closed-outline" text="Bank-level 256-bit encryption" />
+        <SecurityItem icon="eye-off-outline" text="Credentials never stored on our servers" />
+        <SecurityItem icon="refresh-outline" text="Read-only access — we can't move your money" />
+
+        <Pressable
+          style={({ pressed }) => [styles.btn, pressed && styles.btnPressed]}
+          onPress={startPlaid}
+          disabled={loading}
+          accessibilityRole="button"
+          accessibilityLabel="Connect via Plaid"
+        >
+          {loading ? (
+            <ActivityIndicator color={Colors.textInverse} />
+          ) : (
+            <>
+              <Ionicons name="link-outline" size={20} color={Colors.textInverse} style={styles.btnIcon} />
+              <Text style={styles.btnText}>Connect via Plaid</Text>
+            </>
+          )}
+        </Pressable>
+
+        <Pressable
+          style={styles.skip}
+          onPress={() => router.replace('/(tabs)/')}
+          accessibilityRole="button"
+          accessibilityLabel="Skip bank connection for now"
+        >
+          <Text style={styles.skipText}>Skip for now</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function SecurityItem({ icon, text }: { icon: keyof typeof Ionicons.glyphMap; text: string }) {
+  return (
+    <View style={styles.secRow}>
+      <View style={styles.secIcon}>
+        <Ionicons name={icon} size={16} color={Colors.success} />
+      </View>
+      <Text style={styles.secText}>{text}</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 32, backgroundColor: '#fff' },
-  title: { fontSize: 28, fontWeight: '800', color: '#111', marginBottom: 12 },
-  subtitle: { fontSize: 15, color: '#666', textAlign: 'center', marginBottom: 40, lineHeight: 22 },
-  btn: { backgroundColor: '#007AFF', borderRadius: 14, paddingVertical: 16, paddingHorizontal: 32, minWidth: 220, alignItems: 'center' },
-  btnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
-  skip: { marginTop: 20 },
-  skipText: { color: '#007AFF', fontSize: 15 },
+  root: { flex: 1, backgroundColor: Colors.hero },
+
+  hero: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.xxxl,
+    paddingTop: 60,
+  },
+  stepRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: Spacing.xxl,
+  },
+  stepDot: {
+    width: 10,
+    height: 10,
+    borderRadius: Radius.full,
+    backgroundColor: 'rgba(255,255,255,0.35)',
+  },
+  stepDotDone: { backgroundColor: Colors.success },
+  stepDotActive: { backgroundColor: Colors.textInverse, width: 12, height: 12 },
+  stepLine: { width: 40, height: 2, backgroundColor: 'rgba(255,255,255,0.25)', marginHorizontal: Spacing.sm },
+
+  iconRing: {
+    width: 72,
+    height: 72,
+    borderRadius: Radius.xl,
+    backgroundColor: Colors.surface,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: Spacing.xl,
+    ...Shadow.md,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: Colors.textInverse,
+    letterSpacing: -0.3,
+    marginBottom: Spacing.sm,
+  },
+  subtitle: {
+    fontSize: 15,
+    color: 'rgba(255,255,255,0.65)',
+    textAlign: 'center',
+  },
+
+  card: {
+    backgroundColor: Colors.surface,
+    borderTopLeftRadius: Radius.xxl,
+    borderTopRightRadius: Radius.xxl,
+    padding: Spacing.xxl,
+    paddingBottom: 40,
+    ...Shadow.md,
+  },
+
+  secRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: Spacing.lg,
+  },
+  secIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: Radius.sm,
+    backgroundColor: Colors.successLight,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: Spacing.md,
+  },
+  secText: {
+    flex: 1,
+    fontSize: 14,
+    color: Colors.textSecondary,
+    lineHeight: 20,
+  },
+
+  btn: {
+    backgroundColor: Colors.primary,
+    borderRadius: Radius.lg,
+    paddingVertical: 16,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    minHeight: 52,
+    marginTop: Spacing.sm,
+    ...Shadow.sm,
+  },
+  btnPressed: { backgroundColor: Colors.primaryDark },
+  btnIcon: { marginRight: Spacing.sm },
+  btnText: { color: Colors.textInverse, fontSize: 16, fontWeight: '700' },
+
+  skip: { paddingVertical: Spacing.lg, alignItems: 'center', marginTop: Spacing.xs },
+  skipText: { color: Colors.textSecondary, fontSize: 15, fontWeight: '500' },
 });

--- a/mobile/app/(auth)/index.tsx
+++ b/mobile/app/(auth)/index.tsx
@@ -1,11 +1,13 @@
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import * as Linking from 'expo-linking';
-import { Pressable, StyleSheet, Text, View, ActivityIndicator } from 'react-native';
+import { Pressable, StatusBar, StyleSheet, Text, View, ActivityIndicator } from 'react-native';
 import { useState } from 'react';
 import Constants from 'expo-constants';
+import { Ionicons } from '@expo/vector-icons';
 import { useAuthStore } from '@/stores/authStore';
 import { usePlaidStore } from '@/stores/plaidStore';
+import { Colors, Radius, Shadow, Spacing } from '@/lib/theme';
 
 const REDIRECT_URI = 'spliteasy://oauth/callback';
 const CLIENT_ID: string = Constants.expoConfig?.extra?.splitwiseClientId ?? '';
@@ -41,24 +43,159 @@ export default function WelcomeScreen() {
   }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>SplitEasy</Text>
-      <Text style={styles.subtitle}>Stop forgetting to split expenses.</Text>
-      <Pressable style={styles.btn} onPress={handleSignIn} disabled={loading}>
-        {loading ? (
-          <ActivityIndicator color="#fff" />
-        ) : (
-          <Text style={styles.btnText}>Sign in with Splitwise</Text>
-        )}
-      </Pressable>
+    <View style={styles.root}>
+      <StatusBar barStyle="light-content" backgroundColor={Colors.hero} />
+
+      {/* Hero section */}
+      <View style={styles.hero}>
+        <View style={styles.logoRing}>
+          <Ionicons name="swap-horizontal" size={32} color={Colors.primary} />
+        </View>
+        <Text style={styles.appName}>SplitEasy</Text>
+        <Text style={styles.tagline}>Split expenses with friends,{'\n'}effortlessly.</Text>
+      </View>
+
+      {/* Content card */}
+      <View style={styles.card}>
+        <View style={styles.featureRow}>
+          <FeatureItem icon="card-outline" label="Link your bank" />
+          <FeatureItem icon="people-outline" label="Pick friends" />
+          <FeatureItem icon="checkmark-circle-outline" label="Split & done" />
+        </View>
+
+        <Text style={styles.hint}>
+          Sign in with Splitwise to see your friends and create shared expenses automatically.
+        </Text>
+
+        <Pressable
+          style={({ pressed }) => [styles.btn, pressed && styles.btnPressed]}
+          onPress={handleSignIn}
+          disabled={loading}
+          accessibilityRole="button"
+          accessibilityLabel="Sign in with Splitwise"
+        >
+          {loading ? (
+            <ActivityIndicator color={Colors.textInverse} />
+          ) : (
+            <>
+              <Ionicons name="log-in-outline" size={20} color={Colors.textInverse} style={styles.btnIcon} />
+              <Text style={styles.btnText}>Sign in with Splitwise</Text>
+            </>
+          )}
+        </Pressable>
+
+        <Text style={styles.legal}>
+          Your bank credentials are never stored on any server.
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function FeatureItem({ icon, label }: { icon: keyof typeof Ionicons.glyphMap; label: string }) {
+  return (
+    <View style={styles.feature}>
+      <View style={styles.featureIcon}>
+        <Ionicons name={icon} size={20} color={Colors.primary} />
+      </View>
+      <Text style={styles.featureLabel}>{label}</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 32, backgroundColor: '#fff' },
-  title: { fontSize: 36, fontWeight: '800', color: '#111', marginBottom: 8 },
-  subtitle: { fontSize: 16, color: '#666', marginBottom: 48, textAlign: 'center' },
-  btn: { backgroundColor: '#5C7AEA', borderRadius: 14, paddingVertical: 16, paddingHorizontal: 32, minWidth: 220, alignItems: 'center' },
-  btnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+  root: { flex: 1, backgroundColor: Colors.hero },
+
+  hero: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.xxxl,
+    paddingTop: 60,
+  },
+  logoRing: {
+    width: 72,
+    height: 72,
+    borderRadius: Radius.xl,
+    backgroundColor: Colors.surface,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: Spacing.xl,
+    ...Shadow.md,
+  },
+  appName: {
+    fontSize: 36,
+    fontWeight: '800',
+    color: Colors.textInverse,
+    letterSpacing: -0.5,
+    marginBottom: Spacing.sm,
+  },
+  tagline: {
+    fontSize: 17,
+    color: 'rgba(255,255,255,0.72)',
+    textAlign: 'center',
+    lineHeight: 26,
+  },
+
+  card: {
+    backgroundColor: Colors.surface,
+    borderTopLeftRadius: Radius.xxl,
+    borderTopRightRadius: Radius.xxl,
+    padding: Spacing.xxl,
+    paddingBottom: 40,
+    ...Shadow.md,
+  },
+  featureRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: Spacing.xxl,
+  },
+  feature: {
+    alignItems: 'center',
+    flex: 1,
+  },
+  featureIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: Radius.md,
+    backgroundColor: Colors.primaryMuted,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: Spacing.sm,
+  },
+  featureLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: Colors.textSecondary,
+    textAlign: 'center',
+  },
+
+  hint: {
+    fontSize: 14,
+    color: Colors.textSecondary,
+    lineHeight: 21,
+    textAlign: 'center',
+    marginBottom: Spacing.xl,
+  },
+  btn: {
+    backgroundColor: Colors.primary,
+    borderRadius: Radius.lg,
+    paddingVertical: 16,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    minHeight: 52,
+    ...Shadow.sm,
+  },
+  btnPressed: { backgroundColor: Colors.primaryDark },
+  btnIcon: { marginRight: Spacing.sm },
+  btnText: { color: Colors.textInverse, fontSize: 16, fontWeight: '700' },
+
+  legal: {
+    fontSize: 12,
+    color: Colors.textTertiary,
+    textAlign: 'center',
+    marginTop: Spacing.lg,
+    lineHeight: 18,
+  },
 });

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,9 +1,10 @@
-// mobile/app/(tabs)/_layout.tsx
 import { Tabs } from 'expo-router';
 import { useEffect } from 'react';
+import { Ionicons } from '@expo/vector-icons';
 import { useTransactionStore } from '@/stores/transactionStore';
 import { useFriendStore } from '@/stores/friendStore';
 import { pruneOldTransactions } from '@/lib/db';
+import { Colors } from '@/lib/theme';
 
 export default function TabsLayout() {
   const count = useTransactionStore((s) => s.transactions.length);
@@ -15,16 +16,60 @@ export default function TabsLayout() {
   }, []);
 
   return (
-    <Tabs screenOptions={{ headerShown: false }}>
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: Colors.tabActive,
+        tabBarInactiveTintColor: Colors.tabInactive,
+        tabBarStyle: {
+          backgroundColor: Colors.surface,
+          borderTopColor: '#E2E8F0',
+          borderTopWidth: 1,
+          paddingTop: 6,
+          paddingBottom: 4,
+          height: 60,
+        },
+        tabBarLabelStyle: {
+          fontSize: 11,
+          fontWeight: '600',
+          marginTop: 2,
+        },
+      }}
+    >
       <Tabs.Screen
         name="index"
         options={{
-          title: 'New',
+          title: 'Transactions',
           tabBarBadge: count > 0 ? count : undefined,
+          tabBarBadgeStyle: {
+            backgroundColor: Colors.primary,
+            fontSize: 10,
+            minWidth: 18,
+            height: 18,
+          },
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="receipt-outline" size={size} color={color} />
+          ),
         }}
       />
-      <Tabs.Screen name="history" options={{ title: 'History' }} />
-      <Tabs.Screen name="settings" options={{ title: 'Settings' }} />
+      <Tabs.Screen
+        name="history"
+        options={{
+          title: 'History',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="time-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: 'Settings',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="person-circle-outline" size={size} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/mobile/app/(tabs)/history.tsx
+++ b/mobile/app/(tabs)/history.tsx
@@ -1,10 +1,14 @@
 import { useState, useCallback } from 'react';
-import { FlatList, StyleSheet, Text, View } from 'react-native';
+import { FlatList, StatusBar, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFocusEffect } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
 import { getHistoryTransactions } from '@/lib/db';
 import { TransactionWithSplit } from '@/lib/types';
+import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
 
 export default function HistoryScreen() {
+  const insets = useSafeAreaInsets();
   const [rows, setRows] = useState<TransactionWithSplit[]>([]);
 
   useFocusEffect(
@@ -13,62 +17,178 @@ export default function HistoryScreen() {
     }, [])
   );
 
-  if (rows.length === 0) {
-    return (
-      <View style={styles.center}>
-        <Text style={styles.emptyIcon}>🕘</Text>
-        <Text style={styles.emptyTitle}>No history yet</Text>
-        <Text style={styles.emptySubtitle}>Split or skip transactions to see them here.</Text>
-      </View>
-    );
-  }
-
   return (
-    <FlatList
-      data={rows}
-      keyExtractor={(r) => r.id}
-      contentContainerStyle={styles.list}
-      renderItem={({ item }) => <HistoryRow item={item} />}
-    />
+    <View style={[styles.root, { paddingTop: insets.top }]}>
+      <StatusBar barStyle="dark-content" backgroundColor={Colors.bg} />
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>History</Text>
+        {rows.length > 0 && (
+          <Text style={styles.headerSub}>{rows.length} transaction{rows.length !== 1 ? 's' : ''}</Text>
+        )}
+      </View>
+
+      {rows.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <FlatList
+          data={rows}
+          keyExtractor={(r) => r.id}
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => <HistoryRow item={item} />}
+        />
+      )}
+    </View>
+  );
+}
+
+function EmptyState() {
+  return (
+    <View style={styles.emptyContainer}>
+      <View style={styles.emptyIcon}>
+        <Ionicons name="time-outline" size={40} color={Colors.textTertiary} />
+      </View>
+      <Text style={styles.emptyTitle}>No history yet</Text>
+      <Text style={styles.emptySubtitle}>
+        Split or skip transactions to see them here.
+      </Text>
+    </View>
   );
 }
 
 function HistoryRow({ item }: { item: TransactionWithSplit }) {
   const date = new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   const isSplit = item.status === 'split' && item.split;
+  const initial = (item.merchant_name ?? '?')[0].toUpperCase();
+  const avatarColor = merchantColor(item.merchant_name ?? '?');
 
   return (
     <View style={styles.card}>
-      <View style={styles.top}>
-        <Text style={styles.merchant} numberOfLines={1}>{item.merchant_name}</Text>
-        <Text style={styles.amount}>${item.amount.toFixed(2)}</Text>
+      <View style={[styles.avatar, { backgroundColor: avatarColor + '20' }]}>
+        <Text style={[styles.avatarText, { color: avatarColor }]}>{initial}</Text>
       </View>
-      <View style={styles.bottom}>
+      <View style={styles.info}>
+        <Text style={styles.merchant} numberOfLines={1}>{item.merchant_name}</Text>
         <Text style={styles.date}>{date}</Text>
         {isSplit ? (
-          <Text style={styles.splitLabel}>
-            {item.split!.friend_names.join(', ')} · ${item.split!.amount_each.toFixed(2)} each
-          </Text>
+          <View style={styles.splitBadge}>
+            <Ionicons name="people-outline" size={11} color={Colors.success} style={{ marginRight: 3 }} />
+            <Text style={styles.splitText}>
+              {item.split!.friend_names.join(', ')} · ${item.split!.amount_each.toFixed(2)} each
+            </Text>
+          </View>
         ) : (
-          <Text style={styles.skippedLabel}>Skipped</Text>
+          <View style={styles.skippedBadge}>
+            <Text style={styles.skippedText}>Skipped</Text>
+          </View>
         )}
       </View>
+      <Text style={styles.amount}>${item.amount.toFixed(2)}</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  list: { padding: 16, gap: 10 },
-  center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 32 },
-  emptyIcon: { fontSize: 40, marginBottom: 12 },
-  emptyTitle: { fontSize: 18, fontWeight: '700', color: '#111' },
-  emptySubtitle: { fontSize: 14, color: '#888', marginTop: 4, textAlign: 'center' },
-  card: { backgroundColor: '#fff', borderRadius: 12, padding: 14, shadowColor: '#000', shadowOpacity: 0.04, shadowRadius: 3, elevation: 1 },
-  top: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 4 },
-  bottom: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  merchant: { fontSize: 15, fontWeight: '600', flex: 1, marginRight: 8 },
-  amount: { fontSize: 15, fontWeight: '700' },
-  date: { fontSize: 12, color: '#888' },
-  splitLabel: { fontSize: 12, color: '#1c7c54', flex: 1, textAlign: 'right' },
-  skippedLabel: { fontSize: 12, color: '#888' },
+  root: { flex: 1, backgroundColor: Colors.bg },
+
+  header: {
+    paddingHorizontal: Spacing.xl,
+    paddingTop: Spacing.lg,
+    paddingBottom: Spacing.md,
+  },
+  headerTitle: {
+    fontSize: 26,
+    fontWeight: '800',
+    color: Colors.textPrimary,
+    letterSpacing: -0.5,
+  },
+  headerSub: {
+    fontSize: 13,
+    color: Colors.textSecondary,
+    marginTop: 2,
+    fontWeight: '500',
+  },
+
+  list: { padding: Spacing.lg, paddingTop: Spacing.sm, gap: 8 },
+
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: Spacing.xxxl,
+  },
+  emptyIcon: {
+    width: 80,
+    height: 80,
+    borderRadius: Radius.xxl,
+    backgroundColor: Colors.surfaceMuted,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: Spacing.xl,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    marginBottom: Spacing.sm,
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: Colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 21,
+  },
+
+  card: {
+    backgroundColor: Colors.surface,
+    borderRadius: Radius.lg,
+    padding: Spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    ...Shadow.sm,
+  },
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: Radius.md,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: Spacing.md,
+  },
+  avatarText: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  info: { flex: 1, marginRight: Spacing.sm },
+  merchant: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: Colors.textPrimary,
+    marginBottom: 2,
+  },
+  date: {
+    fontSize: 12,
+    color: Colors.textTertiary,
+    marginBottom: 6,
+  },
+  splitBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  splitText: {
+    fontSize: 12,
+    color: Colors.success,
+    fontWeight: '500',
+    flex: 1,
+  },
+  skippedBadge: {},
+  skippedText: {
+    fontSize: 12,
+    color: Colors.textTertiary,
+    fontWeight: '500',
+  },
+  amount: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+  },
 });

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { FlatList, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { FlatList, RefreshControl, StatusBar, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import NetInfo from '@react-native-community/netinfo';
 import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
 import { useTransactionStore } from '@/stores/transactionStore';
 import { usePlaidStore } from '@/stores/plaidStore';
 import { TransactionRow } from '@/components/TransactionRow';
@@ -11,9 +13,11 @@ import { FriendPickerSheet } from '@/components/FriendPickerSheet';
 import { useToast } from '@/components/ToastProvider';
 import { Transaction } from '@/lib/types';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { Colors, Spacing, Radius } from '@/lib/theme';
 
 export default function NewTransactionsScreen() {
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   const { transactions, isLoading, load, refresh, skip } = useTransactionStore();
   const needsReauth = usePlaidStore((s) => s.needs_reauth);
   const [isConnected, setIsConnected] = useState(true);
@@ -38,35 +42,52 @@ export default function NewTransactionsScreen() {
     toast.show(`Added! Others owe you $${amountEach.toFixed(2)}`, 'success');
   }
 
-  async function handleReauth() {
+  function handleReauth() {
     router.push('/(auth)/bank-connect');
   }
 
-  if (isLoading && transactions.length === 0) {
-    return (
-      <View style={styles.center}>
-        <Text style={styles.empty}>Loading transactions…</Text>
-      </View>
-    );
-  }
+  const isEmptyAndLoaded = !isLoading && transactions.length === 0;
 
   return (
-    <View style={styles.flex}>
+    <View style={[styles.root, { paddingTop: insets.top }]}>
+      <StatusBar barStyle="dark-content" backgroundColor={Colors.bg} />
+
+      {/* Header */}
+      <View style={styles.header}>
+        <View>
+          <Text style={styles.headerTitle}>Transactions</Text>
+          {transactions.length > 0 && (
+            <Text style={styles.headerSub}>
+              {transactions.length} pending split{transactions.length !== 1 ? 's' : ''}
+            </Text>
+          )}
+        </View>
+        {transactions.length > 0 && (
+          <View style={styles.badge}>
+            <Text style={styles.badgeText}>{transactions.length}</Text>
+          </View>
+        )}
+      </View>
+
       {needsReauth && <ReauthBanner onPress={handleReauth} />}
       {!isConnected && <OfflineBanner />}
 
-      {transactions.length === 0 ? (
-        <View style={styles.center}>
-          <Text style={styles.emptyIcon}>🪣</Text>
-          <Text style={styles.emptyTitle}>No new transactions</Text>
-          <Text style={styles.emptySubtitle}>New transactions will appear here.</Text>
-        </View>
+      {isLoading && transactions.length === 0 ? (
+        <LoadingSkeleton />
+      ) : isEmptyAndLoaded ? (
+        <EmptyState />
       ) : (
         <FlatList
           data={transactions}
           keyExtractor={(t) => t.id}
           contentContainerStyle={styles.list}
-          refreshControl={<RefreshControl refreshing={isLoading} onRefresh={refresh} />}
+          refreshControl={
+            <RefreshControl
+              refreshing={isLoading}
+              onRefresh={refresh}
+              tintColor={Colors.primary}
+            />
+          }
           renderItem={({ item }) => (
             <TransactionRow
               transaction={item}
@@ -86,12 +107,125 @@ export default function NewTransactionsScreen() {
   );
 }
 
+function EmptyState() {
+  return (
+    <View style={styles.emptyContainer}>
+      <View style={styles.emptyIcon}>
+        <Ionicons name="checkmark-done-circle-outline" size={48} color={Colors.success} />
+      </View>
+      <Text style={styles.emptyTitle}>All caught up!</Text>
+      <Text style={styles.emptySubtitle}>
+        New transactions from your connected bank will appear here.
+      </Text>
+    </View>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <View style={styles.list}>
+      {[1, 2, 3].map((i) => (
+        <View key={i} style={styles.skeletonCard}>
+          <View style={styles.skeletonAvatar} />
+          <View style={styles.skeletonLines}>
+            <View style={[styles.skeletonLine, { width: '55%' }]} />
+            <View style={[styles.skeletonLine, { width: '30%', marginTop: 6 }]} />
+          </View>
+          <View style={[styles.skeletonLine, { width: 52, height: 20 }]} />
+        </View>
+      ))}
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
-  flex: { flex: 1, backgroundColor: '#f5f5f5' },
-  list: { padding: 16, gap: 12 },
-  center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 32 },
-  emptyIcon: { fontSize: 48, marginBottom: 12 },
-  emptyTitle: { fontSize: 18, fontWeight: '700', color: '#111' },
-  emptySubtitle: { fontSize: 14, color: '#888', marginTop: 4 },
-  empty: { color: '#888' },
+  root: { flex: 1, backgroundColor: Colors.bg },
+
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.xl,
+    paddingTop: Spacing.lg,
+    paddingBottom: Spacing.md,
+    backgroundColor: Colors.bg,
+  },
+  headerTitle: {
+    fontSize: 26,
+    fontWeight: '800',
+    color: Colors.textPrimary,
+    letterSpacing: -0.5,
+  },
+  headerSub: {
+    fontSize: 13,
+    color: Colors.textSecondary,
+    marginTop: 2,
+    fontWeight: '500',
+  },
+  badge: {
+    backgroundColor: Colors.primary,
+    borderRadius: Radius.full,
+    minWidth: 28,
+    height: 28,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.sm,
+  },
+  badgeText: {
+    color: Colors.textInverse,
+    fontSize: 13,
+    fontWeight: '700',
+  },
+
+  list: { padding: Spacing.lg, gap: 10 },
+
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: Spacing.xxxl,
+  },
+  emptyIcon: {
+    width: 80,
+    height: 80,
+    borderRadius: Radius.xxl,
+    backgroundColor: Colors.successLight,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: Spacing.xl,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    marginBottom: Spacing.sm,
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: Colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 21,
+  },
+
+  skeletonCard: {
+    backgroundColor: Colors.surface,
+    borderRadius: Radius.lg,
+    padding: Spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 2,
+  },
+  skeletonAvatar: {
+    width: 44,
+    height: 44,
+    borderRadius: Radius.md,
+    backgroundColor: Colors.surfaceMuted,
+    marginRight: Spacing.md,
+  },
+  skeletonLines: { flex: 1, marginRight: Spacing.md },
+  skeletonLine: {
+    height: 14,
+    borderRadius: Radius.sm,
+    backgroundColor: Colors.surfaceMuted,
+  },
 });

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -1,68 +1,248 @@
-import { Alert, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Alert, Image, Pressable, StatusBar, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
 import { useAuthStore } from '@/stores/authStore';
 import { usePlaidStore } from '@/stores/plaidStore';
+import { Colors, Radius, Shadow, Spacing } from '@/lib/theme';
 
 export default function SettingsScreen() {
+  const insets = useSafeAreaInsets();
   const { display_name, avatar_url, signOut } = useAuthStore();
   const { institution_name, isLinked, disconnect } = usePlaidStore();
 
   function confirmSignOut() {
-    Alert.alert('Sign Out', 'This will remove all local data from this device. Your Splitwise data is safe.', [
-      { text: 'Cancel', style: 'cancel' },
-      { text: 'Sign Out', style: 'destructive', onPress: signOut },
-    ]);
+    Alert.alert(
+      'Sign Out',
+      'This will remove all local data from this device. Your Splitwise data is safe.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Sign Out', style: 'destructive', onPress: signOut },
+      ]
+    );
   }
 
   function confirmDisconnect() {
-    Alert.alert('Disconnect Bank', 'This will remove your bank connection and all local transactions.', [
-      { text: 'Cancel', style: 'cancel' },
-      { text: 'Disconnect', style: 'destructive', onPress: disconnect },
-    ]);
+    Alert.alert(
+      'Disconnect Bank',
+      'This will remove your bank connection and all local transactions.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Disconnect', style: 'destructive', onPress: disconnect },
+      ]
+    );
   }
 
+  const initials = display_name
+    ? display_name.split(' ').map((w) => w[0]).join('').slice(0, 2).toUpperCase()
+    : '?';
+
   return (
-    <View style={styles.container}>
-      {/* Splitwise account */}
-      <Text style={styles.sectionTitle}>Splitwise Account</Text>
-      <View style={styles.card}>
+    <View style={[styles.root, { paddingTop: insets.top }]}>
+      <StatusBar barStyle="dark-content" backgroundColor={Colors.bg} />
+
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Settings</Text>
+      </View>
+
+      {/* Profile section */}
+      <View style={styles.profileCard}>
         {avatar_url ? (
           <Image source={{ uri: avatar_url }} style={styles.avatar} />
         ) : (
-          <View style={[styles.avatar, styles.avatarFallback]} />
+          <View style={[styles.avatar, styles.avatarFallback]}>
+            <Text style={styles.avatarInitials}>{initials}</Text>
+          </View>
         )}
-        <Text style={styles.name}>{display_name ?? 'Unknown'}</Text>
-        <Pressable style={styles.dangerBtn} onPress={confirmSignOut}>
-          <Text style={styles.dangerText}>Sign Out</Text>
-        </Pressable>
+        <View style={styles.profileInfo}>
+          <Text style={styles.profileName}>{display_name ?? 'Unknown'}</Text>
+          <Text style={styles.profileSub}>Splitwise account</Text>
+        </View>
+        <View style={styles.splitwiseBadge}>
+          <Ionicons name="checkmark-circle" size={16} color={Colors.success} />
+          <Text style={styles.splitwiseBadgeText}>Connected</Text>
+        </View>
       </View>
 
-      {/* Bank account */}
-      <Text style={styles.sectionTitle}>Connected Bank</Text>
-      <View style={styles.card}>
+      {/* Settings sections */}
+      <Text style={styles.sectionLabel}>Bank Account</Text>
+      <View style={styles.settingsCard}>
         {isLinked ? (
           <>
-            <Text style={styles.institution}>{institution_name ?? 'Connected'}</Text>
-            <Pressable style={styles.dangerBtn} onPress={confirmDisconnect}>
-              <Text style={styles.dangerText}>Disconnect</Text>
+            <View style={styles.settingRow}>
+              <View style={styles.settingIcon}>
+                <Ionicons name="business-outline" size={18} color={Colors.primary} />
+              </View>
+              <View style={styles.settingContent}>
+                <Text style={styles.settingTitle}>{institution_name ?? 'Connected bank'}</Text>
+                <Text style={styles.settingDesc}>Transactions synced via Plaid</Text>
+              </View>
+              <View style={styles.connectedDot} />
+            </View>
+            <View style={styles.divider} />
+            <Pressable
+              style={({ pressed }) => [styles.settingRow, pressed && styles.rowPressed]}
+              onPress={confirmDisconnect}
+              accessibilityRole="button"
+            >
+              <View style={[styles.settingIcon, styles.settingIconDanger]}>
+                <Ionicons name="unlink-outline" size={18} color={Colors.error} />
+              </View>
+              <Text style={[styles.settingTitle, styles.dangerText]}>Disconnect bank</Text>
+              <Ionicons name="chevron-forward" size={16} color={Colors.textTertiary} />
             </Pressable>
           </>
         ) : (
-          <Text style={styles.noBank}>No bank connected</Text>
+          <View style={styles.settingRow}>
+            <View style={[styles.settingIcon, { backgroundColor: Colors.surfaceMuted }]}>
+              <Ionicons name="business-outline" size={18} color={Colors.textTertiary} />
+            </View>
+            <View style={styles.settingContent}>
+              <Text style={styles.settingTitle}>No bank connected</Text>
+              <Text style={styles.settingDesc}>Connect a bank to import transactions</Text>
+            </View>
+          </View>
         )}
+      </View>
+
+      <Text style={styles.sectionLabel}>Account</Text>
+      <View style={styles.settingsCard}>
+        <Pressable
+          style={({ pressed }) => [styles.settingRow, pressed && styles.rowPressed]}
+          onPress={confirmSignOut}
+          accessibilityRole="button"
+        >
+          <View style={[styles.settingIcon, styles.settingIconDanger]}>
+            <Ionicons name="log-out-outline" size={18} color={Colors.error} />
+          </View>
+          <Text style={[styles.settingTitle, styles.dangerText]}>Sign out</Text>
+          <Ionicons name="chevron-forward" size={16} color={Colors.textTertiary} />
+        </Pressable>
       </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#f5f5f5', padding: 20 },
-  sectionTitle: { fontSize: 13, fontWeight: '600', color: '#888', textTransform: 'uppercase', marginBottom: 8, marginTop: 24 },
-  card: { backgroundColor: '#fff', borderRadius: 12, padding: 16, flexDirection: 'row', alignItems: 'center', gap: 12 },
-  avatar: { width: 40, height: 40, borderRadius: 20 },
-  avatarFallback: { backgroundColor: '#ddd' },
-  name: { flex: 1, fontSize: 15, fontWeight: '600', color: '#111' },
-  institution: { flex: 1, fontSize: 15, fontWeight: '600', color: '#111' },
-  noBank: { flex: 1, fontSize: 15, color: '#888' },
-  dangerBtn: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8, backgroundColor: '#FEE2E2' },
-  dangerText: { color: '#c0392b', fontWeight: '600', fontSize: 13 },
+  root: { flex: 1, backgroundColor: Colors.bg },
+
+  header: {
+    paddingHorizontal: Spacing.xl,
+    paddingTop: Spacing.lg,
+    paddingBottom: Spacing.md,
+  },
+  headerTitle: {
+    fontSize: 26,
+    fontWeight: '800',
+    color: Colors.textPrimary,
+    letterSpacing: -0.5,
+  },
+
+  profileCard: {
+    backgroundColor: Colors.surface,
+    marginHorizontal: Spacing.lg,
+    borderRadius: Radius.xl,
+    padding: Spacing.xl,
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: Spacing.xxl,
+    ...Shadow.sm,
+  },
+  avatar: {
+    width: 52,
+    height: 52,
+    borderRadius: Radius.full,
+    marginRight: Spacing.md,
+  },
+  avatarFallback: {
+    backgroundColor: Colors.primaryLight,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  avatarInitials: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: Colors.primary,
+  },
+  profileInfo: { flex: 1 },
+  profileName: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+  },
+  profileSub: {
+    fontSize: 12,
+    color: Colors.textSecondary,
+    marginTop: 2,
+  },
+  splitwiseBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.successLight,
+    borderRadius: Radius.full,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 4,
+    gap: 4,
+  },
+  splitwiseBadgeText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: Colors.success,
+  },
+
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.textSecondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    paddingHorizontal: Spacing.xl,
+    marginBottom: Spacing.sm,
+  },
+  settingsCard: {
+    backgroundColor: Colors.surface,
+    marginHorizontal: Spacing.lg,
+    borderRadius: Radius.xl,
+    marginBottom: Spacing.xxl,
+    overflow: 'hidden',
+    ...Shadow.sm,
+  },
+  settingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: Spacing.lg,
+  },
+  rowPressed: { backgroundColor: Colors.surfaceMuted },
+  settingIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: Radius.sm,
+    backgroundColor: Colors.primaryMuted,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: Spacing.md,
+  },
+  settingIconDanger: { backgroundColor: Colors.errorLight },
+  settingContent: { flex: 1 },
+  settingTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: Colors.textPrimary,
+  },
+  settingDesc: {
+    fontSize: 12,
+    color: Colors.textSecondary,
+    marginTop: 2,
+  },
+  dangerText: { color: Colors.error, flex: 1 },
+  connectedDot: {
+    width: 8,
+    height: 8,
+    borderRadius: Radius.full,
+    backgroundColor: Colors.success,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: Colors.divider,
+    marginLeft: 16 + 36 + 12,
+  },
 });

--- a/mobile/components/FriendPickerSheet.tsx
+++ b/mobile/components/FriendPickerSheet.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from 'react-native';
 import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
+import { Ionicons } from '@expo/vector-icons';
 import { useFriendStore } from '@/stores/friendStore';
 import { useAuthStore } from '@/stores/authStore';
 import { useTransactionStore } from '@/stores/transactionStore';
@@ -16,6 +17,7 @@ import { getSplitDecision, insertSplitDecision, updateTransactionStatus } from '
 import { createExpense, SplitwiseAuthError } from '@/lib/splitwise';
 import { SplitwiseFriend, Transaction } from '@/lib/types';
 import { useToast } from '@/components/ToastProvider';
+import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
 
 interface Props {
   transaction: Transaction | null;
@@ -48,7 +50,6 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       if (selected.size === 0 || submitting) return;
       setSubmitting(true);
       try {
-        // Idempotency check
         const existing = await getSplitDecision(transaction!.id);
         if (existing) {
           await updateTransactionStatus(transaction!.id, 'split');
@@ -66,7 +67,6 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
           friendIds: selectedFriends.map((f) => f.id),
         });
 
-        // Write split_decision + update status (retry up to 3 times)
         for (let attempt = 1; attempt <= 3; attempt++) {
           try {
             await insertSplitDecision({
@@ -97,25 +97,55 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       }
     }
 
+    const merchantInitial = (transaction.merchant_name ?? '?')[0].toUpperCase();
+    const merchantBg = merchantColor(transaction.merchant_name ?? '?');
+
     return (
-      <BottomSheetModal ref={ref} snapPoints={['60%', '90%']} enablePanDownToClose>
+      <BottomSheetModal
+        ref={ref}
+        snapPoints={['55%', '85%']}
+        enablePanDownToClose
+        handleIndicatorStyle={styles.indicator}
+        backgroundStyle={styles.sheetBg}
+      >
         <BottomSheetView style={styles.container}>
-          <Text style={styles.header}>{transaction.merchant_name}</Text>
-          <Text style={styles.amount}>${transaction.amount.toFixed(2)}</Text>
+          {/* Transaction summary */}
+          <View style={styles.txSummary}>
+            <View style={[styles.txAvatar, { backgroundColor: merchantBg + '18' }]}>
+              <Text style={[styles.txAvatarText, { color: merchantBg }]}>{merchantInitial}</Text>
+            </View>
+            <View style={styles.txInfo}>
+              <Text style={styles.txMerchant} numberOfLines={1}>{transaction.merchant_name}</Text>
+              <Text style={styles.txTotal}>${transaction.amount.toFixed(2)}</Text>
+            </View>
+          </View>
+
+          {/* Split preview */}
           {selected.size > 0 && (
-            <Text style={styles.share}>
-              ${amountEach.toFixed(2)} each ({n} people)
-            </Text>
+            <View style={styles.splitPreview}>
+              <Ionicons name="people-outline" size={16} color={Colors.primary} style={{ marginRight: 6 }} />
+              <Text style={styles.splitPreviewText}>
+                ${amountEach.toFixed(2)} each · {n} people
+              </Text>
+            </View>
           )}
 
+          {/* Section label */}
+          <Text style={styles.sectionLabel}>Select friends to split with</Text>
+
+          {/* Friends list */}
           {isLoading ? (
-            <ActivityIndicator style={styles.spinner} />
+            <ActivityIndicator color={Colors.primary} style={styles.spinner} />
           ) : friends.length === 0 ? (
-            <Text style={styles.empty}>No Splitwise friends found.</Text>
+            <View style={styles.emptyContainer}>
+              <Ionicons name="people-outline" size={32} color={Colors.textTertiary} />
+              <Text style={styles.emptyText}>No Splitwise friends found.</Text>
+            </View>
           ) : (
             <FlatList
               data={friends}
               keyExtractor={(f) => f.id}
+              style={styles.friendList}
               renderItem={({ item }) => (
                 <FriendRow
                   friend={item}
@@ -126,15 +156,32 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
             />
           )}
 
+          {/* CTA */}
           <Pressable
-            style={[styles.addBtn, (selected.size === 0 || submitting) && styles.addBtnDisabled]}
+            style={({ pressed }) => [
+              styles.addBtn,
+              (selected.size === 0 || submitting) && styles.addBtnDisabled,
+              pressed && selected.size > 0 && !submitting && styles.addBtnPressed,
+            ]}
             onPress={handleAddToSplitwise}
             disabled={selected.size === 0 || submitting}
+            accessibilityRole="button"
+            accessibilityLabel="Add split to Splitwise"
           >
             {submitting ? (
-              <ActivityIndicator color="#fff" />
+              <ActivityIndicator color={Colors.textInverse} />
             ) : (
-              <Text style={styles.addBtnText}>Add to Splitwise</Text>
+              <>
+                <Ionicons
+                  name="checkmark-circle-outline"
+                  size={18}
+                  color={selected.size === 0 ? Colors.textTertiary : Colors.textInverse}
+                  style={{ marginRight: 6 }}
+                />
+                <Text style={[styles.addBtnText, selected.size === 0 && styles.addBtnTextDisabled]}>
+                  Add to Splitwise
+                </Text>
+              </>
             )}
           </Pressable>
         </BottomSheetView>
@@ -143,31 +190,167 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
   }
 );
 
-function FriendRow({ friend, isSelected, onToggle }: {
+function FriendRow({
+  friend,
+  isSelected,
+  onToggle,
+}: {
   friend: SplitwiseFriend;
   isSelected: boolean;
   onToggle: () => void;
 }) {
+  const initial = friend.display_name[0].toUpperCase();
+  const avatarColor = merchantColor(friend.display_name);
+
   return (
-    <Pressable style={[styles.row, isSelected && styles.rowSelected]} onPress={onToggle}>
-      <Text style={styles.rowName}>{friend.display_name}</Text>
-      {isSelected && <Text style={styles.check}>✓</Text>}
+    <Pressable
+      style={({ pressed }) => [
+        styles.friendRow,
+        isSelected && styles.friendRowSelected,
+        pressed && !isSelected && styles.friendRowPressed,
+      ]}
+      onPress={onToggle}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: isSelected }}
+      accessibilityLabel={friend.display_name}
+    >
+      <View style={[styles.friendAvatar, { backgroundColor: avatarColor + '18' }]}>
+        <Text style={[styles.friendAvatarText, { color: avatarColor }]}>{initial}</Text>
+      </View>
+      <Text style={[styles.friendName, isSelected && styles.friendNameSelected]}>
+        {friend.display_name}
+      </Text>
+      <View style={[styles.checkbox, isSelected && styles.checkboxSelected]}>
+        {isSelected && <Ionicons name="checkmark" size={13} color={Colors.textInverse} />}
+      </View>
     </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20 },
-  header: { fontSize: 18, fontWeight: '700', color: '#111' },
-  amount: { fontSize: 28, fontWeight: '800', color: '#111', marginVertical: 4 },
-  share: { fontSize: 14, color: '#555', marginBottom: 12 },
+  indicator: { backgroundColor: Colors.border, width: 36 },
+  sheetBg: { backgroundColor: Colors.surface },
+  container: { flex: 1, paddingHorizontal: Spacing.xl, paddingTop: Spacing.sm },
+
+  txSummary: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: Spacing.md,
+  },
+  txAvatar: {
+    width: 48,
+    height: 48,
+    borderRadius: Radius.md,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: Spacing.md,
+  },
+  txAvatarText: { fontSize: 20, fontWeight: '700' },
+  txInfo: { flex: 1 },
+  txMerchant: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+  },
+  txTotal: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: Colors.textPrimary,
+    letterSpacing: -0.5,
+  },
+
+  splitPreview: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.primaryMuted,
+    borderRadius: Radius.md,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+    marginBottom: Spacing.md,
+  },
+  splitPreviewText: {
+    fontSize: 14,
+    color: Colors.primary,
+    fontWeight: '600',
+  },
+
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.textSecondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    marginBottom: Spacing.sm,
+  },
+
   spinner: { marginTop: 40 },
-  empty: { color: '#888', textAlign: 'center', marginTop: 40 },
-  row: { paddingVertical: 14, paddingHorizontal: 16, borderRadius: 10, marginBottom: 8, backgroundColor: '#f5f5f5', flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  rowSelected: { backgroundColor: '#EBF2FF' },
-  rowName: { fontSize: 15, color: '#111' },
-  check: { fontSize: 16, color: '#007AFF' },
-  addBtn: { backgroundColor: '#007AFF', borderRadius: 14, paddingVertical: 16, alignItems: 'center', marginTop: 16 },
-  addBtnDisabled: { backgroundColor: '#B0C8F5' },
-  addBtnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+  emptyContainer: {
+    alignItems: 'center',
+    paddingTop: 40,
+    gap: Spacing.md,
+  },
+  emptyText: {
+    fontSize: 14,
+    color: Colors.textSecondary,
+  },
+
+  friendList: { flex: 1 },
+  friendRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.md,
+    borderRadius: Radius.md,
+    marginBottom: Spacing.xs,
+    backgroundColor: Colors.surfaceMuted,
+  },
+  friendRowSelected: { backgroundColor: Colors.primaryMuted },
+  friendRowPressed: { backgroundColor: Colors.border },
+  friendAvatar: {
+    width: 36,
+    height: 36,
+    borderRadius: Radius.sm,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: Spacing.md,
+  },
+  friendAvatarText: { fontSize: 14, fontWeight: '700' },
+  friendName: {
+    flex: 1,
+    fontSize: 15,
+    color: Colors.textPrimary,
+    fontWeight: '500',
+  },
+  friendNameSelected: { fontWeight: '600', color: Colors.primary },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: Radius.sm,
+    borderWidth: 1.5,
+    borderColor: Colors.border,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.surface,
+  },
+  checkboxSelected: {
+    backgroundColor: Colors.primary,
+    borderColor: Colors.primary,
+  },
+
+  addBtn: {
+    backgroundColor: Colors.primary,
+    borderRadius: Radius.lg,
+    paddingVertical: 16,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: Spacing.md,
+    marginBottom: Spacing.md,
+    minHeight: 52,
+    ...Shadow.sm,
+  },
+  addBtnDisabled: { backgroundColor: Colors.surfaceMuted },
+  addBtnPressed: { backgroundColor: Colors.primaryDark },
+  addBtnText: { color: Colors.textInverse, fontSize: 16, fontWeight: '700' },
+  addBtnTextDisabled: { color: Colors.textTertiary },
 });

--- a/mobile/components/OfflineBanner.tsx
+++ b/mobile/components/OfflineBanner.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Colors, Spacing } from '@/lib/theme';
 
 export function OfflineBanner() {
   return (
     <View style={styles.banner}>
+      <Ionicons name="cloud-offline-outline" size={14} color={Colors.textInverse} style={styles.icon} />
       <Text style={styles.text}>No internet connection</Text>
     </View>
   );
@@ -11,9 +14,16 @@ export function OfflineBanner() {
 
 const styles = StyleSheet.create({
   banner: {
-    backgroundColor: '#c0392b',
-    paddingVertical: 8,
+    backgroundColor: Colors.textPrimary,
+    flexDirection: 'row',
+    justifyContent: 'center',
     alignItems: 'center',
+    paddingVertical: Spacing.sm,
   },
-  text: { color: '#fff', fontSize: 13 },
+  icon: { marginRight: Spacing.xs },
+  text: {
+    color: Colors.textInverse,
+    fontSize: 13,
+    fontWeight: '500',
+  },
 });

--- a/mobile/components/ReauthBanner.tsx
+++ b/mobile/components/ReauthBanner.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Colors, Radius, Spacing } from '@/lib/theme';
 
 interface Props {
   onPress: () => void;
@@ -8,8 +10,14 @@ interface Props {
 export function ReauthBanner({ onPress }: Props) {
   return (
     <View style={styles.banner}>
-      <Text style={styles.text}>Your bank connection needs attention.</Text>
-      <Pressable onPress={onPress} style={styles.btn}>
+      <Ionicons name="warning-outline" size={16} color="#7C2D12" style={styles.icon} />
+      <Text style={styles.text}>Bank connection needs attention.</Text>
+      <Pressable
+        onPress={onPress}
+        style={({ pressed }) => [styles.btn, pressed && styles.btnPressed]}
+        accessibilityRole="button"
+        accessibilityLabel="Reconnect bank"
+      >
         <Text style={styles.btnText}>Reconnect</Text>
       </Pressable>
     </View>
@@ -18,14 +26,28 @@ export function ReauthBanner({ onPress }: Props) {
 
 const styles = StyleSheet.create({
   banner: {
-    backgroundColor: '#e67e22',
+    backgroundColor: Colors.warningLight,
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 16,
-    paddingVertical: 10,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.sm + 2,
+    borderBottomWidth: 1,
+    borderBottomColor: '#FDE68A',
   },
-  text: { color: '#fff', fontSize: 13, flex: 1, marginRight: 8 },
-  btn: { backgroundColor: 'rgba(255,255,255,0.25)', borderRadius: 6, paddingHorizontal: 10, paddingVertical: 4 },
-  btnText: { color: '#fff', fontSize: 13, fontWeight: '600' },
+  icon: { marginRight: Spacing.sm },
+  text: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '500',
+    color: '#7C2D12',
+    marginRight: Spacing.sm,
+  },
+  btn: {
+    backgroundColor: '#F59E0B',
+    borderRadius: Radius.sm,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: 5,
+  },
+  btnPressed: { backgroundColor: '#D97706' },
+  btnText: { color: '#fff', fontSize: 12, fontWeight: '700' },
 });

--- a/mobile/components/ToastProvider.tsx
+++ b/mobile/components/ToastProvider.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, useCallback, useContext, useRef, useState } from 'react';
 import { Animated, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Colors, Radius, Shadow, Spacing } from '@/lib/theme';
 
 type ToastStyle = 'success' | 'error';
 
@@ -17,28 +19,39 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [message, setMessage] = useState('');
   const [style, setStyle] = useState<ToastStyle>('success');
   const opacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(12)).current;
   const timer = useRef<ReturnType<typeof setTimeout>>();
 
   const show = useCallback((msg: string, s: ToastStyle = 'success') => {
     if (timer.current) clearTimeout(timer.current);
     setMessage(msg);
     setStyle(s);
-    Animated.sequence([
+    Animated.parallel([
       Animated.timing(opacity, { toValue: 1, duration: 200, useNativeDriver: true }),
-      Animated.delay(2600),
-      Animated.timing(opacity, { toValue: 0, duration: 200, useNativeDriver: true }),
+      Animated.spring(translateY, { toValue: 0, useNativeDriver: true, damping: 15, stiffness: 180 }),
     ]).start();
-    timer.current = setTimeout(() => setMessage(''), 3000);
-  }, [opacity]);
+    timer.current = setTimeout(() => {
+      Animated.parallel([
+        Animated.timing(opacity, { toValue: 0, duration: 200, useNativeDriver: true }),
+        Animated.timing(translateY, { toValue: 12, duration: 200, useNativeDriver: true }),
+      ]).start(() => setMessage(''));
+    }, 2800);
+  }, [opacity, translateY]);
+
+  const icon: keyof typeof Ionicons.glyphMap =
+    style === 'success' ? 'checkmark-circle-outline' : 'alert-circle-outline';
 
   return (
     <ToastContext.Provider value={{ show }}>
       {children}
       {message ? (
         <Animated.View
-          style={[styles.toast, style === 'error' ? styles.error : styles.success, { opacity }]}
+          style={[styles.toast, { opacity, transform: [{ translateY }] }]}
           pointerEvents="none"
         >
+          <View style={[styles.iconContainer, style === 'error' ? styles.errorIcon : styles.successIcon]}>
+            <Ionicons name={icon} size={16} color={Colors.textInverse} />
+          </View>
           <Text style={styles.text}>{message}</Text>
         </Animated.View>
       ) : null}
@@ -49,14 +62,32 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
 const styles = StyleSheet.create({
   toast: {
     position: 'absolute',
-    bottom: 100,
-    left: 24,
-    right: 24,
-    padding: 14,
-    borderRadius: 10,
+    bottom: 96,
+    left: Spacing.xxl,
+    right: Spacing.xxl,
+    backgroundColor: Colors.textPrimary,
+    borderRadius: Radius.xl,
+    flexDirection: 'row',
     alignItems: 'center',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    ...Shadow.md,
   },
-  success: { backgroundColor: '#1c7c54' },
-  error: { backgroundColor: '#c0392b' },
-  text: { color: '#fff', fontSize: 14, fontWeight: '600' },
+  iconContainer: {
+    width: 26,
+    height: 26,
+    borderRadius: Radius.full,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: Spacing.md,
+  },
+  successIcon: { backgroundColor: Colors.success },
+  errorIcon: { backgroundColor: Colors.error },
+  text: {
+    flex: 1,
+    color: Colors.textInverse,
+    fontSize: 14,
+    fontWeight: '500',
+    lineHeight: 20,
+  },
 });

--- a/mobile/components/TransactionRow.tsx
+++ b/mobile/components/TransactionRow.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { Transaction } from '@/lib/types';
+import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
 
 interface Props {
   transaction: Transaction;
@@ -14,19 +16,42 @@ export function TransactionRow({ transaction, onSkip, onSplit }: Props) {
     month: 'short',
     day: 'numeric',
   });
+  const initial = (transaction.merchant_name ?? '?')[0].toUpperCase();
+  const avatarBg = merchantColor(transaction.merchant_name ?? '?');
 
   return (
     <View style={styles.card}>
+      {/* Merchant avatar */}
+      <View style={[styles.avatar, { backgroundColor: avatarBg + '18' }]}>
+        <Text style={[styles.avatarText, { color: avatarBg }]}>{initial}</Text>
+      </View>
+
+      {/* Info */}
       <View style={styles.info}>
         <Text style={styles.merchant} numberOfLines={1}>{transaction.merchant_name}</Text>
         <Text style={styles.date}>{date}</Text>
       </View>
+
+      {/* Amount */}
       <Text style={styles.amount}>{amount}</Text>
+
+      {/* Actions */}
       <View style={styles.actions}>
-        <Pressable style={[styles.btn, styles.skip]} onPress={onSkip}>
-          <Text style={styles.skipText}>Skip</Text>
+        <Pressable
+          style={({ pressed }) => [styles.btn, styles.skipBtn, pressed && styles.skipBtnPressed]}
+          onPress={onSkip}
+          accessibilityRole="button"
+          accessibilityLabel={`Skip ${transaction.merchant_name}`}
+        >
+          <Ionicons name="close-outline" size={14} color={Colors.textSecondary} />
         </Pressable>
-        <Pressable style={[styles.btn, styles.split]} onPress={onSplit}>
+        <Pressable
+          style={({ pressed }) => [styles.btn, styles.splitBtn, pressed && styles.splitBtnPressed]}
+          onPress={onSplit}
+          accessibilityRole="button"
+          accessibilityLabel={`Split ${transaction.merchant_name}`}
+        >
+          <Ionicons name="people-outline" size={14} color={Colors.textInverse} style={{ marginRight: 3 }} />
           <Text style={styles.splitText}>Split</Text>
         </Pressable>
       </View>
@@ -36,25 +61,59 @@ export function TransactionRow({ transaction, onSkip, onSplit }: Props) {
 
 const styles = StyleSheet.create({
   card: {
-    backgroundColor: '#fff',
-    borderRadius: 12,
-    padding: 16,
+    backgroundColor: Colors.surface,
+    borderRadius: Radius.lg,
+    padding: Spacing.lg,
     flexDirection: 'row',
     alignItems: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    shadowOffset: { width: 0, height: 2 },
-    elevation: 2,
+    ...Shadow.sm,
   },
-  info: { flex: 1, marginRight: 8 },
-  merchant: { fontSize: 15, fontWeight: '600', color: '#111' },
-  date: { fontSize: 12, color: '#888', marginTop: 2 },
-  amount: { fontSize: 15, fontWeight: '700', color: '#111', marginRight: 12 },
-  actions: { flexDirection: 'row', gap: 8 },
-  btn: { borderRadius: 8, paddingHorizontal: 12, paddingVertical: 6 },
-  skip: { backgroundColor: '#f0f0f0' },
-  split: { backgroundColor: '#007AFF' },
-  skipText: { fontSize: 13, color: '#555' },
-  splitText: { fontSize: 13, color: '#fff', fontWeight: '600' },
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: Radius.md,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: Spacing.md,
+  },
+  avatarText: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  info: { flex: 1, marginRight: Spacing.sm },
+  merchant: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: Colors.textPrimary,
+    marginBottom: 2,
+  },
+  date: {
+    fontSize: 12,
+    color: Colors.textTertiary,
+  },
+  amount: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    marginRight: Spacing.md,
+  },
+  actions: { flexDirection: 'row', gap: 6 },
+  btn: {
+    borderRadius: Radius.md,
+    paddingVertical: 7,
+    paddingHorizontal: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 34,
+  },
+  skipBtn: { backgroundColor: Colors.surfaceMuted },
+  skipBtnPressed: { backgroundColor: Colors.border },
+  splitBtn: { backgroundColor: Colors.primary },
+  splitBtnPressed: { backgroundColor: Colors.primaryDark },
+  splitText: {
+    fontSize: 13,
+    color: Colors.textInverse,
+    fontWeight: '600',
+  },
 });

--- a/mobile/lib/theme.ts
+++ b/mobile/lib/theme.ts
@@ -1,0 +1,77 @@
+// Design tokens for SplitEasy — sourced from ui-ux-pro-max design system
+export const Colors = {
+  primary: '#2563EB',
+  primaryLight: '#DBEAFE',
+  primaryDark: '#1D4ED8',
+  primaryMuted: '#EFF6FF',
+
+  success: '#10B981',
+  successLight: '#D1FAE5',
+  warning: '#F59E0B',
+  warningLight: '#FEF3C7',
+  error: '#EF4444',
+  errorLight: '#FEE2E2',
+
+  bg: '#F8FAFC',
+  surface: '#FFFFFF',
+  surfaceMuted: '#F1F5F9',
+
+  textPrimary: '#0F172A',
+  textSecondary: '#64748B',
+  textTertiary: '#94A3B8',
+  textInverse: '#FFFFFF',
+
+  border: '#E2E8F0',
+  divider: '#F1F5F9',
+
+  hero: '#1E3A5F',
+
+  tabActive: '#2563EB',
+  tabInactive: '#94A3B8',
+};
+
+export const Radius = {
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 20,
+  xxl: 24,
+  full: 999,
+};
+
+export const Shadow = {
+  sm: {
+    shadowColor: '#0F172A',
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 1 },
+    elevation: 2,
+  },
+  md: {
+    shadowColor: '#0F172A',
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 4,
+  },
+};
+
+export const Spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 20,
+  xxl: 24,
+  xxxl: 32,
+};
+
+// Merchant avatar colors — assigned by first char code mod
+const AVATAR_PALETTE = [
+  '#2563EB', '#7C3AED', '#DB2777', '#EA580C',
+  '#16A34A', '#0891B2', '#CA8A04', '#DC2626',
+];
+export function merchantColor(name: string): string {
+  const code = (name.charCodeAt(0) || 0) % AVATAR_PALETTE.length;
+  return AVATAR_PALETTE[code];
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,6 +9,7 @@
     "test": "jest --watchAll=false"
   },
   "dependencies": {
+    "@expo/vector-icons": "~14.0.4",
     "@gorhom/bottom-sheet": "^4.6.0",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/netinfo": "11.4.1",


### PR DESCRIPTION
## Summary
- Add `mobile/lib/theme.ts` — centralized design tokens (colors, spacing, shadows, merchant avatar palette)
- Auth screens: dark navy hero panel + rounded white card bottom (Welcome & Bank Connect), step progress indicator, security guarantee rows
- Tab bar: Ionicons icons (receipt, time, person-circle), styled blue badge
- Transactions screen: page header with pending count badge, skeleton loader, improved empty state
- History screen: deterministic-color merchant initial avatars, split/skipped status badges
- Settings screen: profile card with initials fallback + connected badge, icon-based settings rows
- TransactionRow: colored merchant avatars, icon skip/split buttons
- FriendPickerSheet: friend avatars, checkbox rows, split preview pill
- ReauthBanner: amber warning style; OfflineBanner: dark pill; Toast: spring animation with icon

## Test plan
- [ ] Welcome screen: dark hero + white card, Splitwise sign-in flow
- [ ] Bank connect: step indicator + security rows, Plaid flow
- [ ] Tab bar icons render; badge updates with pending transaction count
- [ ] Transactions: skeleton on first load, empty state, split/skip actions work
- [ ] History: merchant avatars render, split/skipped badges correct
- [ ] Settings: profile card, bank row, sign-out and disconnect confirmations
- [ ] Toast appears with icon and auto-dismisses
- [ ] Reauth (amber) and offline (dark) banners display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)