### PR TITLE
feat: add brand icon, landing page, and privacy policy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,595 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SplitEasy — Smart Expense Splitting</title>
+  <meta name="description" content="SplitEasy automatically detects shared expenses from your bank account and splits them with friends on Splitwise — in seconds." />
+  <meta property="og:title" content="SplitEasy — Smart Expense Splitting" />
+  <meta property="og:description" content="Connect your bank, pick a friend, split instantly." />
+  <meta property="og:type" content="website" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --primary:       #5C7AEA;
+      --primary-dark:  #4A63D0;
+      --primary-light: #EEF1FD;
+      --success:       #22C55E;
+      --success-light: #DCFCE7;
+      --text-primary:  #0F172A;
+      --text-secondary:#475569;
+      --text-muted:    #94A3B8;
+      --bg:            #F8FAFC;
+      --surface:       #FFFFFF;
+      --border:        #E2E8F0;
+      --hero-grad: linear-gradient(135deg, #3B55C8 0%, #5C7AEA 50%, #7B93F0 100%);
+      --radius-sm:  8px;
+      --radius-md:  12px;
+      --radius-lg:  16px;
+      --radius-xl:  24px;
+      --shadow-sm:  0 1px 3px rgba(0,0,0,.06), 0 1px 2px rgba(0,0,0,.04);
+      --shadow-md:  0 4px 16px rgba(0,0,0,.08), 0 2px 6px rgba(0,0,0,.04);
+      --shadow-lg:  0 12px 40px rgba(92,122,234,.18), 0 4px 12px rgba(0,0,0,.06);
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background: var(--bg);
+      color: var(--text-primary);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* ── NAV ── */
+    nav {
+      position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+      background: rgba(255,255,255,.85);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      border-bottom: 1px solid rgba(226,232,240,.6);
+    }
+    .nav-inner {
+      max-width: 1100px; margin: 0 auto;
+      padding: 0 24px;
+      height: 64px;
+      display: flex; align-items: center; justify-content: space-between;
+    }
+    .nav-logo {
+      font-size: 20px; font-weight: 800; color: var(--primary);
+      letter-spacing: -0.5px; text-decoration: none;
+    }
+    .nav-logo span { color: var(--text-primary); }
+    .nav-cta {
+      background: var(--primary); color: #fff;
+      padding: 9px 20px; border-radius: 10px;
+      font-size: 14px; font-weight: 600;
+      text-decoration: none;
+      transition: background .15s;
+    }
+    .nav-cta:hover { background: var(--primary-dark); }
+
+    /* ── HERO ── */
+    .hero {
+      background: var(--hero-grad);
+      padding: 140px 24px 100px;
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+    .hero::before {
+      content: '';
+      position: absolute; inset: 0;
+      background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='30' cy='30' r='1' fill='rgba(255,255,255,0.06)'/%3E%3C/svg%3E") repeat;
+      pointer-events: none;
+    }
+    .hero-badge {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: rgba(255,255,255,.15);
+      border: 1px solid rgba(255,255,255,.25);
+      backdrop-filter: blur(8px);
+      color: #fff;
+      font-size: 13px; font-weight: 600;
+      padding: 6px 14px; border-radius: 100px;
+      margin-bottom: 24px;
+    }
+    .hero-badge-dot {
+      width: 7px; height: 7px;
+      background: var(--success);
+      border-radius: 50%;
+      animation: pulse 2s infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%       { opacity: .6; transform: scale(1.3); }
+    }
+    .hero h1 {
+      font-size: clamp(36px, 6vw, 64px);
+      font-weight: 900;
+      color: #fff;
+      letter-spacing: -1.5px;
+      line-height: 1.1;
+      margin-bottom: 20px;
+    }
+    .hero h1 em {
+      font-style: normal;
+      background: linear-gradient(135deg, #fff 30%, rgba(255,255,255,.6));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .hero p {
+      font-size: clamp(16px, 2vw, 20px);
+      color: rgba(255,255,255,.75);
+      max-width: 560px; margin: 0 auto 40px;
+      line-height: 1.6;
+    }
+    .hero-actions {
+      display: flex; gap: 12px; justify-content: center; flex-wrap: wrap;
+    }
+    .btn-primary {
+      background: #fff; color: var(--primary);
+      padding: 14px 32px; border-radius: var(--radius-lg);
+      font-size: 16px; font-weight: 700;
+      text-decoration: none;
+      box-shadow: var(--shadow-lg);
+      transition: transform .15s, box-shadow .15s;
+    }
+    .btn-primary:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 48px rgba(92,122,234,.28);
+    }
+    .btn-ghost {
+      background: rgba(255,255,255,.15);
+      border: 1px solid rgba(255,255,255,.3);
+      color: #fff;
+      padding: 14px 28px; border-radius: var(--radius-lg);
+      font-size: 16px; font-weight: 600;
+      text-decoration: none;
+      backdrop-filter: blur(8px);
+      transition: background .15s;
+    }
+    .btn-ghost:hover { background: rgba(255,255,255,.22); }
+
+    /* ── TRUST BAR ── */
+    .trust-bar {
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 18px 24px;
+      text-align: center;
+    }
+    .trust-inner {
+      max-width: 900px; margin: 0 auto;
+      display: flex; flex-wrap: wrap; justify-content: center; gap: 28px;
+    }
+    .trust-item {
+      display: flex; align-items: center; gap: 8px;
+      font-size: 13px; font-weight: 600; color: var(--text-secondary);
+    }
+    .trust-icon {
+      width: 28px; height: 28px; border-radius: 8px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 14px;
+    }
+    .ti-green { background: var(--success-light); }
+    .ti-blue  { background: var(--primary-light); }
+
+    /* ── SECTION COMMON ── */
+    section { padding: 96px 24px; }
+    .section-label {
+      font-size: 12px; font-weight: 700; letter-spacing: 1.2px;
+      text-transform: uppercase; color: var(--primary);
+      margin-bottom: 12px;
+    }
+    .section-title {
+      font-size: clamp(28px, 4vw, 42px);
+      font-weight: 900; letter-spacing: -0.8px;
+      color: var(--text-primary);
+      line-height: 1.15;
+      margin-bottom: 16px;
+    }
+    .section-subtitle {
+      font-size: 17px; color: var(--text-secondary);
+      max-width: 520px; line-height: 1.65;
+    }
+    .centered { text-align: center; margin: 0 auto; }
+
+    /* ── HOW IT WORKS ── */
+    .steps-section { background: var(--surface); }
+    .steps-grid {
+      max-width: 1000px; margin: 56px auto 0;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 32px;
+    }
+    .step-card {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      padding: 28px 24px;
+      position: relative;
+      transition: box-shadow .2s, transform .2s;
+    }
+    .step-card:hover {
+      box-shadow: var(--shadow-md);
+      transform: translateY(-2px);
+    }
+    .step-num {
+      position: absolute; top: -14px; left: 24px;
+      background: var(--primary); color: #fff;
+      font-size: 12px; font-weight: 800;
+      width: 28px; height: 28px; border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .step-icon {
+      font-size: 28px; margin-bottom: 12px; line-height: 1;
+    }
+    .step-title {
+      font-size: 16px; font-weight: 700; color: var(--text-primary);
+      margin-bottom: 6px;
+    }
+    .step-desc {
+      font-size: 14px; color: var(--text-secondary); line-height: 1.6;
+    }
+
+    /* ── FEATURES ── */
+    .features-section { background: var(--bg); }
+    .features-grid {
+      max-width: 1100px; margin: 56px auto 0;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 24px;
+    }
+    .feature-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      padding: 28px;
+      box-shadow: var(--shadow-sm);
+      transition: box-shadow .2s, transform .2s;
+    }
+    .feature-card:hover {
+      box-shadow: var(--shadow-md);
+      transform: translateY(-2px);
+    }
+    .feature-icon-wrap {
+      width: 48px; height: 48px;
+      border-radius: var(--radius-md);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 22px; margin-bottom: 16px;
+    }
+    .fi-blue   { background: var(--primary-light); }
+    .fi-green  { background: var(--success-light); }
+    .fi-purple { background: #F3F0FF; }
+    .fi-orange { background: #FFF7ED; }
+    .feature-title {
+      font-size: 16px; font-weight: 700; color: var(--text-primary);
+      margin-bottom: 8px;
+    }
+    .feature-desc {
+      font-size: 14px; color: var(--text-secondary); line-height: 1.65;
+    }
+
+    /* ── SECURITY ── */
+    .security-section {
+      background: linear-gradient(135deg, #0F172A 0%, #1E293B 100%);
+    }
+    .security-section .section-title { color: #fff; }
+    .security-section .section-subtitle { color: #94A3B8; }
+    .security-section .section-label { color: var(--success); }
+    .security-grid {
+      max-width: 900px; margin: 56px auto 0;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 24px;
+    }
+    .security-card {
+      background: rgba(255,255,255,.05);
+      border: 1px solid rgba(255,255,255,.08);
+      border-radius: var(--radius-xl);
+      padding: 24px;
+      display: flex; gap: 16px; align-items: flex-start;
+    }
+    .sec-icon {
+      width: 40px; height: 40px; border-radius: var(--radius-sm);
+      background: rgba(255,255,255,.08);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 18px; flex-shrink: 0;
+    }
+    .sec-title {
+      font-size: 14px; font-weight: 700; color: #fff; margin-bottom: 4px;
+    }
+    .sec-desc { font-size: 13px; color: #94A3B8; line-height: 1.55; }
+
+    /* ── CTA BAND ── */
+    .cta-section {
+      background: var(--surface);
+      border-top: 1px solid var(--border);
+      text-align: center;
+      padding: 80px 24px;
+    }
+    .cta-section .section-title { max-width: 560px; margin: 0 auto 16px; }
+    .cta-section .section-subtitle { max-width: 460px; margin: 0 auto 36px; }
+    .app-store-row {
+      display: flex; justify-content: center; gap: 16px; flex-wrap: wrap;
+    }
+    .store-badge {
+      display: inline-flex; align-items: center; gap: 10px;
+      background: var(--text-primary); color: #fff;
+      padding: 12px 24px; border-radius: var(--radius-md);
+      font-size: 14px; font-weight: 600;
+      text-decoration: none;
+      transition: background .15s, transform .15s;
+    }
+    .store-badge:hover { background: #1E293B; transform: translateY(-1px); }
+    .store-badge svg { flex-shrink: 0; }
+
+    /* ── FOOTER ── */
+    footer {
+      background: #0F172A;
+      color: #94A3B8;
+      padding: 48px 24px 32px;
+    }
+    .footer-inner {
+      max-width: 1100px; margin: 0 auto;
+      display: grid;
+      grid-template-columns: 1fr auto auto;
+      gap: 40px;
+      align-items: start;
+      margin-bottom: 40px;
+    }
+    .footer-brand { font-size: 22px; font-weight: 800; color: var(--primary); letter-spacing: -0.5px; }
+    .footer-tagline { font-size: 13px; color: #64748B; margin-top: 6px; }
+    .footer-col-title { font-size: 11px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: #64748B; margin-bottom: 12px; }
+    .footer-links { list-style: none; display: flex; flex-direction: column; gap: 8px; }
+    .footer-links a { color: #94A3B8; text-decoration: none; font-size: 14px; transition: color .15s; }
+    .footer-links a:hover { color: #fff; }
+    .footer-divider { border: none; border-top: 1px solid rgba(255,255,255,.06); margin: 0 0 24px; }
+    .footer-bottom {
+      max-width: 1100px; margin: 0 auto;
+      display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: 12px;
+      font-size: 13px;
+    }
+
+    /* ── RESPONSIVE ── */
+    @media (max-width: 640px) {
+      .hero { padding: 120px 20px 80px; }
+      section { padding: 64px 20px; }
+      .footer-inner { grid-template-columns: 1fr; }
+      .nav-inner { padding: 0 16px; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="nav-logo">Split<span>Easy</span></a>
+    <a href="mailto:krishna192reddy@gmail.com" class="nav-cta">Contact</a>
+  </div>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-badge">
+    <span class="hero-badge-dot"></span>
+    Now available on iOS
+  </div>
+  <h1>Split expenses<br /><em>without the hassle</em></h1>
+  <p>SplitEasy connects to your bank, detects shared expenses, and splits them with your friends on Splitwise — in just a few taps.</p>
+  <div class="hero-actions">
+    <a href="#how-it-works" class="btn-primary">See how it works</a>
+    <a href="#features" class="btn-ghost">Explore features</a>
+  </div>
+</section>
+
+<!-- TRUST BAR -->
+<div class="trust-bar">
+  <div class="trust-inner">
+    <div class="trust-item">
+      <div class="trust-icon ti-green">🔒</div>
+      Bank-level 256-bit encryption
+    </div>
+    <div class="trust-item">
+      <div class="trust-icon ti-blue">🏦</div>
+      Powered by Plaid
+    </div>
+    <div class="trust-item">
+      <div class="trust-icon ti-green">👁️</div>
+      Read-only bank access
+    </div>
+    <div class="trust-item">
+      <div class="trust-icon ti-blue">🤝</div>
+      Splitwise integration
+    </div>
+    <div class="trust-item">
+      <div class="trust-icon ti-green">📵</div>
+      Credentials never stored
+    </div>
+  </div>
+</div>
+
+<!-- HOW IT WORKS -->
+<section class="steps-section" id="how-it-works">
+  <div style="max-width:1000px; margin:0 auto; text-align:center;">
+    <p class="section-label centered">How it works</p>
+    <h2 class="section-title centered">Three steps to split anything</h2>
+    <p class="section-subtitle centered">No manual entry. No chasing friends. SplitEasy does the heavy lifting.</p>
+  </div>
+  <div class="steps-grid">
+    <div class="step-card">
+      <div class="step-num">1</div>
+      <div class="step-icon">🏦</div>
+      <div class="step-title">Connect your bank</div>
+      <p class="step-desc">Link your bank account securely via Plaid with read-only access. We never see or store your login credentials.</p>
+    </div>
+    <div class="step-card">
+      <div class="step-num">2</div>
+      <div class="step-icon">🧾</div>
+      <div class="step-title">Review transactions</div>
+      <p class="step-desc">SplitEasy automatically imports new transactions and surfaces the ones worth splitting — restaurants, travel, groceries, and more.</p>
+    </div>
+    <div class="step-card">
+      <div class="step-num">3</div>
+      <div class="step-icon">✅</div>
+      <div class="step-title">Split with friends</div>
+      <p class="step-desc">Pick a friend from your Splitwise contacts, choose equal or custom split amounts, and create the expense instantly.</p>
+    </div>
+    <div class="step-card">
+      <div class="step-num">4</div>
+      <div class="step-icon">📊</div>
+      <div class="step-title">Track history</div>
+      <p class="step-desc">Every split is recorded locally and synced to Splitwise. Review what you've split and what's still pending — all in one place.</p>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section class="features-section" id="features">
+  <div style="max-width:1100px; margin:0 auto; text-align:center;">
+    <p class="section-label centered">Features</p>
+    <h2 class="section-title centered">Everything you need, nothing you don't</h2>
+    <p class="section-subtitle centered">Built for people who share expenses regularly and want a zero-friction way to keep things fair.</p>
+  </div>
+  <div class="features-grid" style="max-width:1100px; margin:56px auto 0;">
+    <div class="feature-card">
+      <div class="feature-icon-wrap fi-blue">💳</div>
+      <div class="feature-title">Multi-bank support</div>
+      <p class="feature-desc">Connect multiple bank accounts or cards. SplitEasy consolidates transactions from all sources into a single feed.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon-wrap fi-green">⚖️</div>
+      <div class="feature-title">Equal &amp; custom splits</div>
+      <p class="feature-desc">Split evenly with one tap, or dial in exact amounts per person for those dinners where everyone ordered differently.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon-wrap fi-purple">🔄</div>
+      <div class="feature-title">Real-time sync</div>
+      <p class="feature-desc">Pull the latest transactions on demand. Plaid's incremental sync keeps things fast without re-importing what you've already seen.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon-wrap fi-orange">📱</div>
+      <div class="feature-title">Splitwise native</div>
+      <p class="feature-desc">Expenses are created directly in Splitwise via the official API. Your friends get notified the moment you hit Submit.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon-wrap fi-blue">📋</div>
+      <div class="feature-title">Local history</div>
+      <p class="feature-desc">A full log of split and skipped transactions lives on-device in SQLite — no cloud account required for your personal history.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon-wrap fi-green">🛡️</div>
+      <div class="feature-title">Privacy first</div>
+      <p class="feature-desc">Bank tokens are stored in the iOS Secure Enclave. Transaction data stays on your device. We don't sell your data to anyone.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECURITY -->
+<section class="security-section" id="security">
+  <div style="max-width:900px; margin:0 auto; text-align:center;">
+    <p class="section-label centered">Security</p>
+    <h2 class="section-title centered">Built with security as a foundation</h2>
+    <p class="section-subtitle centered">Every design decision in SplitEasy was made to protect your financial data.</p>
+  </div>
+  <div class="security-grid">
+    <div class="security-card">
+      <div class="sec-icon">🔐</div>
+      <div>
+        <div class="sec-title">Secure Enclave storage</div>
+        <p class="sec-desc">Plaid access tokens are stored in iOS Secure Enclave (expo-secure-store). They never leave your device unencrypted.</p>
+      </div>
+    </div>
+    <div class="security-card">
+      <div class="sec-icon">👁️</div>
+      <div>
+        <div class="sec-title">Read-only access</div>
+        <p class="sec-desc">SplitEasy requests read-only bank access via Plaid. We can view transactions — we cannot initiate transfers or payments.</p>
+      </div>
+    </div>
+    <div class="security-card">
+      <div class="sec-icon">🚫</div>
+      <div>
+        <div class="sec-title">No credential storage</div>
+        <p class="sec-desc">Your bank username and password pass directly through Plaid's encrypted SDK and are never transmitted to our servers.</p>
+      </div>
+    </div>
+    <div class="security-card">
+      <div class="sec-icon">🔒</div>
+      <div>
+        <div class="sec-title">TLS 1.2+ in transit</div>
+        <p class="sec-desc">All API communication between the app and our Cloudflare Worker backend uses TLS 1.2 or higher with certificate validation.</p>
+      </div>
+    </div>
+    <div class="security-card">
+      <div class="sec-icon">🗑️</div>
+      <div>
+        <div class="sec-title">Right to deletion</div>
+        <p class="sec-desc">Disconnect your bank at any time to permanently delete all local transactions and tokens. No data lingers on our infrastructure.</p>
+      </div>
+    </div>
+    <div class="security-card">
+      <div class="sec-icon">📜</div>
+      <div>
+        <div class="sec-title">Transparent policies</div>
+        <p class="sec-desc">Our <a href="privacy.html" style="color:var(--primary); text-decoration:none;">Privacy Policy</a> and data retention rules are published and written in plain language — no legalese.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section">
+  <p class="section-label centered">Get started</p>
+  <h2 class="section-title">Ready to stop manually splitting?</h2>
+  <p class="section-subtitle centered">SplitEasy is available on iOS. Connect your bank and split your first expense in under two minutes.</p>
+  <div class="app-store-row">
+    <a href="mailto:krishna192reddy@gmail.com" class="store-badge">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg>
+      Request iOS Access
+    </a>
+    <a href="mailto:krishna192reddy@gmail.com" class="store-badge" style="background:#1E293B;">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+      Get in touch
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="footer-inner">
+    <div>
+      <div class="footer-brand">SplitEasy</div>
+      <p class="footer-tagline">Smart expense splitting for people<br/>who share their lives.</p>
+    </div>
+    <div>
+      <div class="footer-col-title">Product</div>
+      <ul class="footer-links">
+        <li><a href="#how-it-works">How it works</a></li>
+        <li><a href="#features">Features</a></li>
+        <li><a href="#security">Security</a></li>
+      </ul>
+    </div>
+    <div>
+      <div class="footer-col-title">Legal</div>
+      <ul class="footer-links">
+        <li><a href="privacy.html">Privacy Policy</a></li>
+        <li><a href="mailto:krishna192reddy@gmail.com">Contact</a></li>
+      </ul>
+    </div>
+  </div>
+  <hr class="footer-divider" />
+  <div class="footer-bottom">
+    <span>© 2026 SplitEasy. All rights reserved.</span>
+    <span>Built with ❤️ using Expo, Plaid &amp; Splitwise</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy — SplitEasy</title>
+  <meta name="description" content="SplitEasy Privacy Policy — how we collect, use, and protect your data." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --primary: #5C7AEA;
+      --text-primary: #0F172A;
+      --text-secondary: #475569;
+      --bg: #F8FAFC;
+      --surface: #FFFFFF;
+      --border: #E2E8F0;
+    }
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background: var(--bg);
+      color: var(--text-primary);
+      line-height: 1.7;
+      -webkit-font-smoothing: antialiased;
+    }
+    nav {
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 0 24px;
+      height: 60px;
+      display: flex; align-items: center; justify-content: space-between;
+    }
+    .nav-logo { font-size: 18px; font-weight: 800; color: var(--primary); text-decoration: none; }
+    .nav-logo span { color: var(--text-primary); }
+    .nav-back { font-size: 14px; font-weight: 500; color: var(--text-secondary); text-decoration: none; }
+    .nav-back:hover { color: var(--primary); }
+    .page-header {
+      background: linear-gradient(135deg, #3B55C8 0%, #5C7AEA 100%);
+      padding: 60px 24px 48px;
+      text-align: center;
+      color: #fff;
+    }
+    .page-header h1 { font-size: 36px; font-weight: 800; letter-spacing: -0.5px; margin-bottom: 8px; }
+    .page-header p { font-size: 15px; color: rgba(255,255,255,.7); }
+    .content { max-width: 720px; margin: 0 auto; padding: 60px 24px 80px; }
+    h2 { font-size: 18px; font-weight: 700; color: var(--text-primary); margin: 36px 0 10px; }
+    p { font-size: 15px; color: var(--text-secondary); margin-bottom: 14px; }
+    ul { margin: 10px 0 14px 20px; }
+    li { font-size: 15px; color: var(--text-secondary); margin-bottom: 6px; line-height: 1.6; }
+    a { color: var(--primary); }
+    .last-updated {
+      font-size: 13px; color: #94A3B8;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 10px 16px; margin-bottom: 36px;
+      display: inline-block;
+    }
+    footer {
+      background: #0F172A; color: #64748B;
+      text-align: center; padding: 28px 24px;
+      font-size: 13px;
+    }
+    footer a { color: #5C7AEA; text-decoration: none; }
+  </style>
+</head>
+<body>
+
+<nav>
+  <a href="/" class="nav-logo">Split<span>Easy</span></a>
+  <a href="index.html" class="nav-back">← Back to home</a>
+</nav>
+
+<div class="page-header">
+  <h1>Privacy Policy</h1>
+  <p>We keep it simple: your data is yours.</p>
+</div>
+
+<div class="content">
+  <span class="last-updated">Last updated: June 12, 2026</span>
+
+  <p>SplitEasy ("we", "our", or "us") is committed to protecting your privacy. This policy explains what information we collect, how we use it, and your rights regarding your data.</p>
+
+  <h2>1. Information We Collect</h2>
+  <p><strong>Bank transaction data.</strong> When you connect a bank account via Plaid, we receive read-only access to your transaction history. This data is stored locally on your device using SQLite and is never transmitted to or stored on our servers beyond the initial Plaid token exchange.</p>
+  <p><strong>Plaid access tokens.</strong> After you authorize a bank connection, Plaid issues an access token. This token is stored securely in the iOS Secure Enclave on your device (via expo-secure-store) and is used solely to fetch your transactions.</p>
+  <p><strong>Splitwise account data.</strong> SplitEasy reads your Splitwise friend list and creates expenses on your behalf using the Splitwise OAuth API. We do not store your Splitwise credentials; only the OAuth access token is retained locally on your device.</p>
+  <p><strong>Usage data.</strong> We do not collect analytics, crash reports, or behavioral tracking data. SplitEasy has no analytics SDK.</p>
+
+  <h2>2. How We Use Your Information</h2>
+  <ul>
+    <li>To display your recent transactions within the app</li>
+    <li>To create Splitwise expenses when you initiate a split</li>
+    <li>To maintain a local history of transactions you have split or skipped</li>
+  </ul>
+  <p>We do not use your data for advertising, profiling, or any purpose beyond providing the core features of SplitEasy.</p>
+
+  <h2>3. Data Storage and Security</h2>
+  <p>All personal and financial data is stored locally on your device. We do not operate a user database or cloud storage for transaction data. Our Cloudflare Worker backend acts as a lightweight proxy for Plaid and Splitwise API calls and does not persist any user data.</p>
+  <p>Security measures include:</p>
+  <ul>
+    <li>Plaid and Splitwise tokens stored in the iOS Secure Enclave</li>
+    <li>All API communication encrypted via TLS 1.2+</li>
+    <li>Read-only Plaid access — we cannot initiate transfers or payments</li>
+    <li>No server-side storage of credentials or transaction data</li>
+  </ul>
+
+  <h2>4. Data Sharing</h2>
+  <p>We do not sell, trade, or share your personal information with third parties, except as required to provide the service:</p>
+  <ul>
+    <li><strong>Plaid Inc.</strong> — for bank account connection and transaction retrieval. Plaid's privacy policy applies to their handling of your bank credentials.</li>
+    <li><strong>Splitwise Inc.</strong> — to create and manage shared expenses on your behalf.</li>
+    <li><strong>Cloudflare, Inc.</strong> — our serverless infrastructure provider. Requests are proxied through Cloudflare Workers; no data is stored.</li>
+  </ul>
+
+  <h2>5. Data Retention</h2>
+  <p>Transaction data and access tokens are retained on your device until you explicitly disconnect a bank account or sign out of the app. Upon disconnection or sign-out:</p>
+  <ul>
+    <li>All Plaid access tokens are deleted from the Secure Enclave</li>
+    <li>All locally cached transactions are deleted from the on-device SQLite database</li>
+    <li>Plaid item cursors are removed from AsyncStorage</li>
+  </ul>
+  <p>We do not retain copies of your data on our infrastructure after you remove the connection.</p>
+
+  <h2>6. Your Rights</h2>
+  <p>You have the right to:</p>
+  <ul>
+    <li><strong>Access</strong> — view what data the app holds by using the app interface</li>
+    <li><strong>Deletion</strong> — delete all local data by disconnecting your bank and signing out</li>
+    <li><strong>Revoke access</strong> — disconnect your Plaid link at any time from the Settings screen</li>
+    <li><strong>Data portability</strong> — your Splitwise expense history is available directly through Splitwise</li>
+  </ul>
+
+  <h2>7. Children's Privacy</h2>
+  <p>SplitEasy is not intended for children under 13 years of age. We do not knowingly collect personal information from children under 13.</p>
+
+  <h2>8. Changes to This Policy</h2>
+  <p>We may update this Privacy Policy from time to time. We will notify users of material changes by updating the "Last updated" date above. Continued use of the app after changes constitutes acceptance of the revised policy.</p>
+
+  <h2>9. Contact Us</h2>
+  <p>If you have questions or concerns about this Privacy Policy or how your data is handled, please contact us:</p>
+  <p><strong>Email:</strong> <a href="mailto:krishna192reddy@gmail.com">krishna192reddy@gmail.com</a></p>
+</div>
+
+<footer>
+  <p>© 2026 SplitEasy. <a href="index.html">Home</a> · <a href="mailto:krishna192reddy@gmail.com">Contact</a></p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **App icon**: replaces the blank placeholder with the SplitEasy brand icon (blue gradient split-fork mark) for iOS and Android
- **Landing page**: adds \`docs/index.html\` for GitHub Pages at \`https://0xbala-k.github.io/SplitEasy\`
- **Privacy policy**: adds \`docs/privacy.html\` linked from the landing page
- **Logo SVG**: adds \`docs/logo.svg\` (source for the icon, also usable for Plaid account setup upload)
- **app.json**: adds \`icon\` field pointing to \`assets/icon.png\`; sets Android adaptive icon background to brand color \`#5C7AEA\`

## After merging

1. Enable GitHub Pages: repo **Settings → Pages → Source: \`main\` / \`/docs\`**
2. Rebuild the iOS app (\`npx expo run:ios\`) to pick up the new icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)