### PR TITLE
Show only post-connection transactions + swipe right to skip

### DIFF
--- a/docs/superpowers/specs/2026-06-12-fresh-transactions-swipe-skip-design.md
+++ b/docs/superpowers/specs/2026-06-12-fresh-transactions-swipe-skip-design.md
@@ -1,0 +1,71 @@
+# Fresh-Transactions-Only Dashboard + Swipe-to-Skip — Design
+
+**Date:** 2026-06-12
+**Status:** Approved (filter method and swipe UX confirmed by user)
+
+## Problem
+
+1. When a user connects a bank account, Plaid's first `/transactions/sync` call
+   returns the historical backlog (typically 90+ days). All of it lands on the
+   dashboard as "pending splits", burying genuinely new transactions.
+2. Skipping a transaction requires tapping a small × button. The user wants a
+   swipe-right gesture to skip.
+
+## Decisions
+
+- **Filter method: drain the first sync.** On the first sync for an account
+  (no saved cursor), fetch the entire backlog but discard the transactions,
+  saving only Plaid's `next_cursor`. Every subsequent sync then returns only
+  transactions that occurred after connection. No date heuristics.
+- **Swipe UX: full swipe skips.** Swiping a row right reveals a "Skip"
+  underlay; releasing past the open threshold (or tapping the revealed action)
+  skips immediately. The existing × button stays as a fallback.
+
+## Changes
+
+### 1. First-sync drain (`mobile/stores/transactionStore.ts`)
+
+In `refresh()`, per account:
+
+- **Cursor is `null` (first sync):** loop `fetchTransactions(token, cursor)`
+  while `has_more` is true, ignoring `added`/`modified`/`removed`. Persist the
+  final `next_cursor` via `saveCursor`. Insert nothing into SQLite.
+- **Cursor exists (incremental sync):** current behavior, but also loop while
+  `has_more` so multi-page updates aren't silently truncated (today only the
+  first page is consumed). Upsert/delete per page, save the final cursor.
+
+The worker already returns `has_more`, and `PlaidTransactionsResponse`
+already includes it; no backend or type changes needed.
+
+Existing linked accounts already have a cursor, so they are unaffected.
+Old rows already in SQLite from before this change are out of scope.
+
+### 2. Swipe-right-to-skip (`mobile/components/TransactionRow.tsx`)
+
+- Wrap the row card in `ReanimatedSwipeable` from
+  `react-native-gesture-handler/ReanimatedSwipeable` (available in the
+  installed v2.20; reanimated v3.16 is already a dependency, and
+  `GestureHandlerRootView` already wraps the app).
+- `renderLeftActions` renders a "Skip" underlay (muted background, close icon
+  + label) revealed by a rightward swipe.
+- `onSwipeableOpen` with direction `left` calls `onSkip()` — a full swipe past
+  the threshold skips without a second tap; tapping the revealed underlay also
+  skips.
+- The × and Split buttons are unchanged. History rows are not swipeable.
+
+## Error handling
+
+- Drain loop failures (network, `ITEM_LOGIN_REQUIRED`) fall through to the
+  existing `refresh()` catch. The cursor is only saved after the drain
+  completes, so a partial drain retries from the start next refresh — sync
+  cursors are replayable, so this is safe and idempotent.
+- Skip-on-swipe reuses the existing `skip(id)` store action (SQLite status
+  update + list removal); no new failure modes.
+
+## Testing
+
+- `transactionStore.test.ts`: first sync (no cursor) drains multi-page
+  backlog, saves final cursor, inserts nothing; incremental sync loops
+  `has_more` pages and upserts each; existing skip/reauth tests unchanged.
+- Swipe behavior verified manually (gesture simulation is unreliable in
+  jest-expo); the skip action itself is already covered by store tests.

--- a/mobile/__tests__/stores/plaidStore.test.ts
+++ b/mobile/__tests__/stores/plaidStore.test.ts
@@ -18,52 +18,97 @@ const mockDeleteItem = SecureStore.deleteItemAsync as jest.Mock;
 const mockExchange = worker.exchangePublicToken as jest.Mock;
 const mockDeleteAll = db.deleteAllTransactions as jest.Mock;
 
-beforeEach(() => {
+beforeEach(async () => {
   jest.clearAllMocks();
+  await AsyncStorage.clear();
+  mockGetItem.mockResolvedValue(null);
   usePlaidStore.setState({
-    institution_name: null,
+    accounts: [],
     needs_reauth: false,
     isLinked: false,
     isHydrated: false,
   });
 });
 
-test('hydrate sets isLinked true when token exists', async () => {
-  mockGetItem.mockResolvedValue('access-sandbox-xyz');
-  await AsyncStorage.setItem('plaid_institution_name', 'Chase');
+test('hydrate sets isLinked true when stored accounts exist', async () => {
+  await AsyncStorage.setItem(
+    'plaid_accounts',
+    JSON.stringify([{ id: 'acct_1', institution_name: 'Chase' }])
+  );
   await usePlaidStore.getState().hydrate();
   expect(usePlaidStore.getState().isLinked).toBe(true);
-  expect(usePlaidStore.getState().institution_name).toBe('Chase');
+  expect(usePlaidStore.getState().accounts).toEqual([{ id: 'acct_1', institution_name: 'Chase' }]);
   expect(usePlaidStore.getState().isHydrated).toBe(true);
 });
 
-test('linkBank exchanges token, stores it, saves institution name', async () => {
+test('hydrate migrates legacy single-account token to accounts format', async () => {
+  mockGetItem.mockImplementation((key: string) =>
+    Promise.resolve(key === 'plaid_access_token' ? 'access-sandbox-xyz' : null)
+  );
+  await AsyncStorage.setItem('plaid_institution_name', 'Chase');
+  await usePlaidStore.getState().hydrate();
+
+  const { accounts, isLinked, isHydrated } = usePlaidStore.getState();
+  expect(isLinked).toBe(true);
+  expect(isHydrated).toBe(true);
+  expect(accounts).toHaveLength(1);
+  expect(accounts[0].institution_name).toBe('Chase');
+  expect(mockSetItem).toHaveBeenCalledWith(`plaid_token_${accounts[0].id}`, 'access-sandbox-xyz');
+  expect(mockDeleteItem).toHaveBeenCalledWith('plaid_access_token');
+  expect(await AsyncStorage.getItem('plaid_accounts')).toBe(JSON.stringify(accounts));
+  expect(await AsyncStorage.getItem('plaid_institution_name')).toBeNull();
+});
+
+test('linkBank exchanges token, stores it, adds account', async () => {
   mockExchange.mockResolvedValue({ access_token: 'access-sandbox-new' });
   mockSetItem.mockResolvedValue(undefined);
 
   await usePlaidStore.getState().linkBank('public-sandbox-abc', 'Chase');
 
+  const { accounts, isLinked } = usePlaidStore.getState();
   expect(mockExchange).toHaveBeenCalledWith('public-sandbox-abc');
-  expect(mockSetItem).toHaveBeenCalledWith('plaid_access_token', 'access-sandbox-new');
-  expect(await AsyncStorage.getItem('plaid_institution_name')).toBe('Chase');
-  expect(await AsyncStorage.getItem('last_plaid_cursor')).toBeNull();
-  expect(usePlaidStore.getState().isLinked).toBe(true);
-  expect(usePlaidStore.getState().institution_name).toBe('Chase');
+  expect(accounts).toHaveLength(1);
+  expect(accounts[0].institution_name).toBe('Chase');
+  expect(mockSetItem).toHaveBeenCalledWith(`plaid_token_${accounts[0].id}`, 'access-sandbox-new');
+  expect(await AsyncStorage.getItem('plaid_accounts')).toBe(JSON.stringify(accounts));
+  expect(isLinked).toBe(true);
 });
 
-test('disconnect clears token, AsyncStorage, all transactions, sets isLinked false', async () => {
+test('disconnect clears tokens, storage, all transactions, sets isLinked false', async () => {
   mockDeleteItem.mockResolvedValue(undefined);
   mockDeleteAll.mockResolvedValue(undefined);
-  usePlaidStore.setState({ isLinked: true, institution_name: 'Chase' });
-  await AsyncStorage.setItem('plaid_institution_name', 'Chase');
+  usePlaidStore.setState({
+    isLinked: true,
+    accounts: [{ id: 'acct_1', institution_name: 'Chase' }],
+  });
+  await AsyncStorage.setItem('plaid_accounts', JSON.stringify([{ id: 'acct_1', institution_name: 'Chase' }]));
 
   await usePlaidStore.getState().disconnect();
 
-  expect(mockDeleteItem).toHaveBeenCalledWith('plaid_access_token');
+  expect(mockDeleteItem).toHaveBeenCalledWith('plaid_token_acct_1');
   expect(mockDeleteAll).toHaveBeenCalled();
-  expect(await AsyncStorage.getItem('plaid_institution_name')).toBeNull();
+  expect(await AsyncStorage.getItem('plaid_accounts')).toBeNull();
   expect(usePlaidStore.getState().isLinked).toBe(false);
-  expect(usePlaidStore.getState().institution_name).toBeNull();
+  expect(usePlaidStore.getState().accounts).toEqual([]);
+});
+
+test('disconnect of one account keeps the others linked', async () => {
+  mockDeleteItem.mockResolvedValue(undefined);
+  mockDeleteAll.mockResolvedValue(undefined);
+  usePlaidStore.setState({
+    isLinked: true,
+    accounts: [
+      { id: 'acct_1', institution_name: 'Chase' },
+      { id: 'acct_2', institution_name: 'Ally' },
+    ],
+  });
+
+  await usePlaidStore.getState().disconnect('acct_1');
+
+  expect(mockDeleteItem).toHaveBeenCalledWith('plaid_token_acct_1');
+  expect(mockDeleteAll).not.toHaveBeenCalled();
+  expect(usePlaidStore.getState().accounts).toEqual([{ id: 'acct_2', institution_name: 'Ally' }]);
+  expect(usePlaidStore.getState().isLinked).toBe(true);
 });
 
 test('setNeedsReauth saves to AsyncStorage and updates store', async () => {

--- a/mobile/__tests__/stores/transactionStore.test.ts
+++ b/mobile/__tests__/stores/transactionStore.test.ts
@@ -1,13 +1,20 @@
 // mobile/__tests__/stores/transactionStore.test.ts
 jest.mock('expo-secure-store');
 jest.mock('@/lib/db');
-jest.mock('@/lib/worker');
+// Explicit factory: keeps WorkerError as the real class so instanceof
+// and .code checks in the store work (automock would strip them).
+jest.mock('@/lib/worker', () => ({
+  WorkerError: jest.requireActual('@/lib/worker').WorkerError,
+  getLinkToken: jest.fn(),
+  exchangePublicToken: jest.fn(),
+  fetchTransactions: jest.fn(),
+  exchangeSplitwiseCode: jest.fn(),
+}));
 jest.mock('@/stores/plaidStore');
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock')
 );
 
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as db from '@/lib/db';
 import * as worker from '@/lib/worker';
 import * as SecureStore from 'expo-secure-store';
@@ -22,16 +29,36 @@ const mockUpdateStatus = db.updateTransactionStatus as jest.Mock;
 const mockFetchTxs = worker.fetchTransactions as jest.Mock;
 const mockSecureGet = SecureStore.getItemAsync as jest.Mock;
 const mockSetNeedsReauth = jest.fn();
+const mockGetTokensAndCursors = jest.fn();
+const mockSaveCursor = jest.fn();
+
+function syncPage(overrides: Partial<{
+  added: unknown[];
+  modified: unknown[];
+  removed: { transaction_id: string }[];
+  next_cursor: string;
+  has_more: boolean;
+}> = {}) {
+  return { added: [], modified: [], removed: [], next_cursor: 'cur-next', has_more: false, ...overrides };
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
-  (usePlaidStore.getState as jest.Mock) = jest.fn().mockReturnValue({ setNeedsReauth: mockSetNeedsReauth });
+  // clearAllMocks doesn't drain mockResolvedValueOnce queues
+  mockFetchTxs.mockReset();
+  (usePlaidStore.getState as jest.Mock) = jest.fn().mockReturnValue({
+    setNeedsReauth: mockSetNeedsReauth,
+    getTokensAndCursors: mockGetTokensAndCursors,
+    saveCursor: mockSaveCursor,
+  });
   useTransactionStore.setState({ transactions: [], isLoading: false });
   mockSecureGet.mockResolvedValue('access-token');
   mockGetNew.mockResolvedValue([]);
   mockUpsert.mockResolvedValue(undefined);
   mockDeleteByIds.mockResolvedValue(undefined);
   mockUpdateStatus.mockResolvedValue(undefined);
+  mockGetTokensAndCursors.mockResolvedValue([{ id: 'acct_1', access_token: 'access-token', cursor: 'cur-0' }]);
+  mockSaveCursor.mockResolvedValue(undefined);
 });
 
 test('load fetches new transactions from DB and updates store', async () => {
@@ -44,17 +71,55 @@ test('load fetches new transactions from DB and updates store', async () => {
 });
 
 test('refresh calls worker, upserts added, deletes removed, updates cursor', async () => {
-  mockFetchTxs.mockResolvedValue({
+  mockFetchTxs.mockResolvedValue(syncPage({
     added: [{ transaction_id: 'tx2', merchant_name: 'Amazon', name: 'AMZN', amount: 29.99, iso_currency_code: 'USD', date: '2026-04-02' }],
-    modified: [],
     removed: [{ transaction_id: 'tx-old' }],
-    next_cursor: 'cur-next',
-    has_more: false,
-  });
+  }));
   await useTransactionStore.getState().refresh();
+  expect(mockFetchTxs).toHaveBeenCalledWith('access-token', 'cur-0');
   expect(mockUpsert).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ transaction_id: 'tx2' })]));
   expect(mockDeleteByIds).toHaveBeenCalledWith(['tx-old']);
-  expect(await AsyncStorage.getItem('last_plaid_cursor')).toBe('cur-next');
+  expect(mockSaveCursor).toHaveBeenCalledWith('acct_1', 'cur-next');
+});
+
+test('refresh follows has_more pages and saves the final cursor', async () => {
+  mockFetchTxs
+    .mockResolvedValueOnce(syncPage({
+      added: [{ transaction_id: 'tx-a', merchant_name: 'A', name: 'A', amount: 1, iso_currency_code: 'USD', date: '2026-06-10' }],
+      next_cursor: 'cur-1',
+      has_more: true,
+    }))
+    .mockResolvedValueOnce(syncPage({
+      added: [{ transaction_id: 'tx-b', merchant_name: 'B', name: 'B', amount: 2, iso_currency_code: 'USD', date: '2026-06-11' }],
+      next_cursor: 'cur-2',
+    }));
+  await useTransactionStore.getState().refresh();
+  expect(mockFetchTxs).toHaveBeenNthCalledWith(1, 'access-token', 'cur-0');
+  expect(mockFetchTxs).toHaveBeenNthCalledWith(2, 'access-token', 'cur-1');
+  expect(mockUpsert).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ transaction_id: 'tx-a' })]));
+  expect(mockUpsert).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ transaction_id: 'tx-b' })]));
+  expect(mockSaveCursor).toHaveBeenLastCalledWith('acct_1', 'cur-2');
+});
+
+test('first sync (no cursor) drains the backlog without storing transactions', async () => {
+  mockGetTokensAndCursors.mockResolvedValue([{ id: 'acct_1', access_token: 'access-token', cursor: null }]);
+  mockFetchTxs
+    .mockResolvedValueOnce(syncPage({
+      added: [{ transaction_id: 'tx-hist-1', merchant_name: 'Old', name: 'Old', amount: 10, iso_currency_code: 'USD', date: '2026-01-05' }],
+      next_cursor: 'cur-1',
+      has_more: true,
+    }))
+    .mockResolvedValueOnce(syncPage({
+      added: [{ transaction_id: 'tx-hist-2', merchant_name: 'Older', name: 'Older', amount: 20, iso_currency_code: 'USD', date: '2026-02-10' }],
+      next_cursor: 'cur-2',
+    }));
+  await useTransactionStore.getState().refresh();
+  expect(mockFetchTxs).toHaveBeenNthCalledWith(1, 'access-token', undefined);
+  expect(mockFetchTxs).toHaveBeenNthCalledWith(2, 'access-token', 'cur-1');
+  expect(mockUpsert).not.toHaveBeenCalled();
+  expect(mockDeleteByIds).not.toHaveBeenCalled();
+  expect(mockSaveCursor).toHaveBeenCalledTimes(1);
+  expect(mockSaveCursor).toHaveBeenCalledWith('acct_1', 'cur-2');
 });
 
 test('refresh sets needs_reauth on ITEM_LOGIN_REQUIRED', async () => {

--- a/mobile/components/TransactionRow.tsx
+++ b/mobile/components/TransactionRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
 import { Ionicons } from '@expo/vector-icons';
 import { Transaction } from '@/lib/types';
 import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
@@ -19,43 +20,65 @@ export function TransactionRow({ transaction, onSkip, onSplit }: Props) {
   const initial = (transaction.merchant_name ?? '?')[0].toUpperCase();
   const avatarBg = merchantColor(transaction.merchant_name ?? '?');
 
+  const renderSkipUnderlay = () => (
+    <Pressable
+      style={styles.skipUnderlay}
+      onPress={onSkip}
+      accessibilityRole="button"
+      accessibilityLabel={`Skip ${transaction.merchant_name}`}
+    >
+      <Ionicons name="close-circle-outline" size={22} color={Colors.textSecondary} />
+      <Text style={styles.skipUnderlayText}>Skip</Text>
+    </Pressable>
+  );
+
   return (
-    <View style={styles.card}>
-      {/* Merchant avatar */}
-      <View style={[styles.avatar, { backgroundColor: avatarBg + '18' }]}>
-        <Text style={[styles.avatarText, { color: avatarBg }]}>{initial}</Text>
-      </View>
+    <ReanimatedSwipeable
+      renderLeftActions={renderSkipUnderlay}
+      onSwipeableOpen={(direction) => {
+        // 'left' = the left underlay opened, i.e. the user swiped right
+        if (direction === 'left') onSkip();
+      }}
+      leftThreshold={72}
+      friction={1.5}
+    >
+      <View style={styles.card}>
+        {/* Merchant avatar */}
+        <View style={[styles.avatar, { backgroundColor: avatarBg + '18' }]}>
+          <Text style={[styles.avatarText, { color: avatarBg }]}>{initial}</Text>
+        </View>
 
-      {/* Info */}
-      <View style={styles.info}>
-        <Text style={styles.merchant} numberOfLines={1}>{transaction.merchant_name}</Text>
-        <Text style={styles.date}>{date}</Text>
-      </View>
+        {/* Info */}
+        <View style={styles.info}>
+          <Text style={styles.merchant} numberOfLines={1}>{transaction.merchant_name}</Text>
+          <Text style={styles.date}>{date}</Text>
+        </View>
 
-      {/* Amount */}
-      <Text style={styles.amount}>{amount}</Text>
+        {/* Amount */}
+        <Text style={styles.amount}>{amount}</Text>
 
-      {/* Actions */}
-      <View style={styles.actions}>
-        <Pressable
-          style={({ pressed }) => [styles.btn, styles.skipBtn, pressed && styles.skipBtnPressed]}
-          onPress={onSkip}
-          accessibilityRole="button"
-          accessibilityLabel={`Skip ${transaction.merchant_name}`}
-        >
-          <Ionicons name="close-outline" size={14} color={Colors.textSecondary} />
-        </Pressable>
-        <Pressable
-          style={({ pressed }) => [styles.btn, styles.splitBtn, pressed && styles.splitBtnPressed]}
-          onPress={onSplit}
-          accessibilityRole="button"
-          accessibilityLabel={`Split ${transaction.merchant_name}`}
-        >
-          <Ionicons name="people-outline" size={14} color={Colors.textInverse} style={{ marginRight: 3 }} />
-          <Text style={styles.splitText}>Split</Text>
-        </Pressable>
+        {/* Actions */}
+        <View style={styles.actions}>
+          <Pressable
+            style={({ pressed }) => [styles.btn, styles.skipBtn, pressed && styles.skipBtnPressed]}
+            onPress={onSkip}
+            accessibilityRole="button"
+            accessibilityLabel={`Skip ${transaction.merchant_name}`}
+          >
+            <Ionicons name="close-outline" size={14} color={Colors.textSecondary} />
+          </Pressable>
+          <Pressable
+            style={({ pressed }) => [styles.btn, styles.splitBtn, pressed && styles.splitBtnPressed]}
+            onPress={onSplit}
+            accessibilityRole="button"
+            accessibilityLabel={`Split ${transaction.merchant_name}`}
+          >
+            <Ionicons name="people-outline" size={14} color={Colors.textInverse} style={{ marginRight: 3 }} />
+            <Text style={styles.splitText}>Split</Text>
+          </Pressable>
+        </View>
       </View>
-    </View>
+    </ReanimatedSwipeable>
   );
 }
 
@@ -106,6 +129,21 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     minHeight: 34,
+  },
+  skipUnderlay: {
+    width: 96,
+    borderRadius: Radius.lg,
+    backgroundColor: Colors.surfaceMuted,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+    marginRight: Spacing.sm,
+  },
+  skipUnderlayText: {
+    fontSize: 13,
+    color: Colors.textSecondary,
+    fontWeight: '600',
   },
   skipBtn: { backgroundColor: Colors.surfaceMuted },
   skipBtnPressed: { backgroundColor: Colors.border },

--- a/mobile/stores/transactionStore.ts
+++ b/mobile/stores/transactionStore.ts
@@ -35,10 +35,24 @@ export const useTransactionStore = create<TransactionState>((set, get) => ({
       const tokensAndCursors = await usePlaidStore.getState().getTokensAndCursors();
       for (const { id, access_token, cursor } of tokensAndCursors) {
         if (!access_token) continue;
-        const res = await fetchTransactions(access_token, cursor ?? undefined);
-        await upsertTransactions([...res.added, ...res.modified]);
-        await deleteTransactionsByPlaidIds(res.removed.map((r) => r.transaction_id));
-        await usePlaidStore.getState().saveCursor(id, res.next_cursor);
+        // First sync (no cursor): drain Plaid's historical backlog without
+        // storing it, so only transactions made after connecting appear.
+        const isFirstSync = cursor == null;
+        let pageCursor = cursor ?? undefined;
+        let hasMore = true;
+        while (hasMore) {
+          const res = await fetchTransactions(access_token, pageCursor);
+          if (!isFirstSync) {
+            await upsertTransactions([...res.added, ...res.modified]);
+            await deleteTransactionsByPlaidIds(res.removed.map((r) => r.transaction_id));
+            await usePlaidStore.getState().saveCursor(id, res.next_cursor);
+          }
+          pageCursor = res.next_cursor;
+          hasMore = res.has_more;
+        }
+        if (isFirstSync && pageCursor) {
+          await usePlaidStore.getState().saveCursor(id, pageCursor);
+        }
       }
       await get().load();
     } catch (err) {


### PR DESCRIPTION
## Summary
- **Fresh transactions only:** on the first Plaid sync after linking an account (no saved cursor), the historical backlog is drained without being stored — only the final sync cursor is kept. The dashboard then fills exclusively with transactions made after connecting. Incremental syncs now also follow `has_more` pages instead of consuming a single page per refresh.
- **Swipe right to skip:** transaction rows are wrapped in `ReanimatedSwipeable`; swiping right reveals a Skip underlay and a full swipe past the threshold skips immediately (tapping the underlay works too). The existing × button remains as a fallback.
- Design spec: `docs/superpowers/specs/2026-06-12-fresh-transactions-swipe-skip-design.md`

## Test repairs (pre-existing failures on main)
The `transactionStore` and `plaidStore` suites were stale after the multi-account refactor and failing on `main` (5 tests). They're rewritten against the current store APIs, with new coverage for first-sync drain, `has_more` pagination, legacy single-account migration, and per-account disconnect.

## Test plan
- [x] `npx jest` — 48/48 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: link a sandbox account → dashboard stays empty until a new transaction posts
- [ ] Manual: swipe a row right → row skips (moves to History as skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)