### PR TITLE
Add pending transaction support

### DIFF
--- a/mobile/components/TransactionRow.tsx
+++ b/mobile/components/TransactionRow.tsx
@@ -51,7 +51,14 @@ export function TransactionRow({ transaction, onSkip, onSplit }: Props) {
         {/* Info */}
         <View style={styles.info}>
           <Text style={styles.merchant} numberOfLines={1}>{transaction.merchant_name}</Text>
-          <Text style={styles.date}>{date}</Text>
+          <View style={styles.dateRow}>
+            <Text style={styles.date}>{date}</Text>
+            {transaction.pending && (
+              <View style={styles.pendingBadge}>
+                <Text style={styles.pendingText}>Pending</Text>
+              </View>
+            )}
+          </View>
         </View>
 
         {/* Amount */}
@@ -108,11 +115,27 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '600',
     color: Colors.textPrimary,
-    marginBottom: 2,
+  },
+  dateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 2,
   },
   date: {
     fontSize: 12,
     color: Colors.textTertiary,
+  },
+  pendingBadge: {
+    backgroundColor: Colors.warningLight,
+    borderRadius: Radius.sm,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+  },
+  pendingText: {
+    fontSize: 10,
+    fontWeight: '600',
+    color: Colors.warning,
   },
   amount: {
     fontSize: 16,

--- a/mobile/lib/db.ts
+++ b/mobile/lib/db.ts
@@ -23,6 +23,7 @@ export async function initDb(): Promise<void> {
         currency TEXT DEFAULT 'USD',
         date TEXT,
         status TEXT DEFAULT 'new',
+        pending INTEGER DEFAULT 0,
         created_at TEXT
       );
       CREATE TABLE IF NOT EXISTS split_decisions (
@@ -34,16 +35,22 @@ export async function initDb(): Promise<void> {
         amount_each REAL,
         created_at TEXT
       );
-      PRAGMA user_version = 1;
+      PRAGMA user_version = 2;
+    `);
+  } else if (version < 2) {
+    await _db.execAsync(`
+      ALTER TABLE transactions ADD COLUMN pending INTEGER DEFAULT 0;
+      PRAGMA user_version = 2;
     `);
   }
 }
 
 export async function getNewTransactions(): Promise<Transaction[]> {
-  return db().getAllAsync<Transaction>(
+  const rows = await db().getAllAsync<Omit<Transaction, 'pending'> & { pending: number }>(
     `SELECT * FROM transactions WHERE status = 'new' ORDER BY date DESC`,
     []
   );
+  return rows.map((r) => ({ ...r, pending: r.pending === 1 }));
 }
 
 export async function getHistoryTransactions(): Promise<TransactionWithSplit[]> {
@@ -75,17 +82,18 @@ export async function upsertTransactions(txs: PlaidTransaction[]): Promise<void>
   for (const tx of txs) {
     const name = tx.merchant_name ?? tx.name;
     const currency = tx.iso_currency_code ?? 'USD';
+    const pending = tx.pending ? 1 : 0;
     // INSERT OR IGNORE preserves status for already-split/skipped rows
     await d.runAsync(
-      `INSERT OR IGNORE INTO transactions (id, merchant_name, amount, currency, date, status, created_at)
-       VALUES (?, ?, ?, ?, ?, 'new', ?)`,
-      [tx.transaction_id, name, tx.amount, currency, tx.date, now]
+      `INSERT OR IGNORE INTO transactions (id, merchant_name, amount, currency, date, status, pending, created_at)
+       VALUES (?, ?, ?, ?, ?, 'new', ?, ?)`,
+      [tx.transaction_id, name, tx.amount, currency, tx.date, pending, now]
     );
     // UPDATE only if still 'new' (don't overwrite user decisions)
     await d.runAsync(
-      `UPDATE transactions SET merchant_name = ?, amount = ?, date = ?
+      `UPDATE transactions SET merchant_name = ?, amount = ?, date = ?, pending = ?
        WHERE id = ? AND status = 'new'`,
-      [name, tx.amount, tx.date, tx.transaction_id]
+      [name, tx.amount, tx.date, pending, tx.transaction_id]
     );
   }
 }

--- a/mobile/lib/types.ts
+++ b/mobile/lib/types.ts
@@ -9,6 +9,7 @@ export interface Transaction {
   currency: string;
   date: string;          // ISO-8601 date e.g. "2026-04-15"
   status: TransactionStatus;
+  pending: boolean;
   created_at: string;    // ISO-8601 datetime; used for 6-month prune
 }
 
@@ -40,6 +41,7 @@ export interface PlaidTransaction {
   amount: number;         // always > 0 after Worker filters credits
   iso_currency_code: string | null;
   date: string;
+  pending: boolean;
 }
 
 export interface PlaidTransactionsResponse {

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -70,6 +70,7 @@ async function handleExchange(req: Request, env: Env): Promise<Response> {
 interface PlaidTransaction {
   transaction_id: string;
   amount: number;
+  pending?: boolean;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Plaid pending transactions (available minutes after a card swipe) are now
stored and displayed. A Pending badge appears below the merchant name until
the transaction settles. Splitting is allowed on pending transactions since
Path A (same transaction_id on settlement) is assumed — the settled update
arrives via `modified` and updates the row without duplicating it.

Schema migrated from v1 to v2 with a new `pending INTEGER DEFAULT 0` column.

https://claude.ai/code/session_013uUqUphyh9yVpdnLnfYXbr