### PR TITLE
perf: smoother friend picker list/search

### DIFF
--- a/mobile/components/FriendPickerSheet.tsx
+++ b/mobile/components/FriendPickerSheet.tsx
@@ -1,14 +1,18 @@
 // mobile/components/FriendPickerSheet.tsx
-import { forwardRef, useEffect, useMemo, useState } from 'react';
+import { forwardRef, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
-  FlatList,
   Pressable,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
-import { BottomSheetModal, BottomSheetView, BottomSheetTextInput } from '@gorhom/bottom-sheet';
+import {
+  BottomSheetModal,
+  BottomSheetView,
+  BottomSheetTextInput,
+  BottomSheetFlatList,
+} from '@gorhom/bottom-sheet';
 import { Ionicons } from '@expo/vector-icons';
 import { useFriendStore } from '@/stores/friendStore';
 import { useAuthStore } from '@/stores/authStore';
@@ -113,13 +117,14 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
     const isOverBudget = ownerShareCents < -1;
     const ctaDisabled = selected.size === 0 || submitting || isOverBudget;
 
-    function toggle(id: string) {
+    // Stable so memoized EqualRows only re-render when their own selection flips.
+    const toggle = useCallback((id: string) => {
       setSelected((prev) => {
         const next = new Set(prev);
         next.has(id) ? next.delete(id) : next.add(id);
         return next;
       });
-    }
+    }, []);
 
     function switchToCustom() {
       const baseShareCents = Math.floor(totalCents / n);
@@ -324,7 +329,7 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
                   <Text style={styles.emptyText}>No Splitwise friends found.</Text>
                 </View>
               ) : (
-                <FlatList
+                <BottomSheetFlatList
                   data={filtered}
                   keyExtractor={(f) => f.id}
                   style={styles.list}
@@ -333,7 +338,7 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
                     <EqualRow
                       friend={item}
                       isSelected={selected.has(item.id)}
-                      onToggle={() => toggle(item.id)}
+                      onToggle={toggle}
                     />
                   )}
                 />
@@ -358,7 +363,7 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
 
               <Text style={styles.sectionLabel}>Custom amounts</Text>
 
-              <FlatList
+              <BottomSheetFlatList
                 data={selectedFriends}
                 keyExtractor={(f) => f.id}
                 style={styles.list}
@@ -410,14 +415,14 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
   }
 );
 
-function EqualRow({
+const EqualRow = memo(function EqualRow({
   friend,
   isSelected,
   onToggle,
 }: {
   friend: SplitwiseFriend;
   isSelected: boolean;
-  onToggle: () => void;
+  onToggle: (id: string) => void;
 }) {
   const initial = friend.display_name[0].toUpperCase();
   const avatarColor = merchantColor(friend.display_name);
@@ -429,7 +434,7 @@ function EqualRow({
         isSelected && styles.friendRowSelected,
         pressed && !isSelected && styles.friendRowPressed,
       ]}
-      onPress={onToggle}
+      onPress={() => onToggle(friend.id)}
       accessibilityRole="checkbox"
       accessibilityState={{ checked: isSelected }}
       accessibilityLabel={friend.display_name}
@@ -445,7 +450,7 @@ function EqualRow({
       </View>
     </Pressable>
   );
-}
+});
 
 function CustomRow({
   friend,


### PR DESCRIPTION
## Context
Investigating reported app glitchiness. **Root cause of the global jank** (janky swipe + general unresponsiveness) was **"Debug Remote JS" being enabled on the device** — that forces JS (incl. Reanimated gesture worklets) off the UI thread and over a socket. Turning it off in the dev menu resolves the swipe/global symptoms; this PR addresses the remaining, code-level cause of the **friend-search input lag**.

## Changes (`FriendPickerSheet.tsx`)
- Swap both friend lists from a plain RN `FlatList` to gorhom's **`BottomSheetFlatList`** — the correct virtualized list inside a bottom sheet (the plain one breaks scroll/gesture handoff).
- **Memoize `EqualRow`** and make `toggle` a stable `useCallback`, so typing in the search box no longer re-renders every visible row.

## Testing
- `npm test` → 71/71 pass (existing FriendPickerSheet edit-mode component tests still green after the refactor)
- `npx tsc --noEmit` → clean

Note: the primary fix for the reported swipe/global jank is a runtime setting (disable Remote JS Debugging), not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)