### PR TITLE
feat: editable split titles + combined transaction splits

### DIFF
--- a/mobile/__tests__/components/FriendPickerSheet.test.tsx
+++ b/mobile/__tests__/components/FriendPickerSheet.test.tsx
@@ -25,6 +25,8 @@ import { SplitDecision, Transaction } from '@/lib/types';
 const mockGetExpense = splitwise.getExpense as jest.Mock;
 const mockUpdateExpense = splitwise.updateExpense as jest.Mock;
 const mockUpsert = db.upsertSplitDecision as jest.Mock;
+const mockInsert = db.insertSplitDecision as jest.Mock;
+const mockCreateExpense = splitwise.createExpense as jest.Mock;
 
 const tx: Transaction = {
   id: 'tx1',
@@ -70,6 +72,9 @@ beforeEach(() => {
   mockGetExpense.mockResolvedValue({ '1': 10, '2': 10 });
   mockUpdateExpense.mockResolvedValue({ amount_each: 10 });
   mockUpsert.mockResolvedValue(undefined);
+  mockCreateExpense.mockResolvedValue({ expense_id: 'expNew', amount_each: 10 });
+  (db.getSplitDecision as jest.Mock).mockResolvedValue(null);
+  mockInsert.mockResolvedValue(undefined);
 });
 
 test('edit mode pre-fills from the existing Splitwise expense', async () => {
@@ -121,4 +126,102 @@ test('re-presenting (openToken change) re-runs the pre-fill', async () => {
     />
   );
   await waitFor(() => expect(mockGetExpense).toHaveBeenCalledTimes(2));
+});
+
+test('edit mode pre-fills the title from the decision description', async () => {
+  render(
+    <FriendPickerSheet
+      transaction={tx}
+      mode="edit"
+      editDecision={{ ...decision, description: 'Weekend trip' }}
+      openToken={1}
+      onSuccess={jest.fn()}
+    />
+  );
+  await waitFor(() => expect(screen.getByDisplayValue('Weekend trip')).toBeTruthy());
+});
+
+test('combine create sums amounts, writes one row per member, and marks each split', async () => {
+  const markSplit = jest.fn();
+  (useTransactionStore as jest.Mock).mockImplementation((sel) => sel({ markSplit }));
+  const members: Transaction[] = [
+    { ...tx, id: 'txA', merchant_name: 'Starbucks', amount: 5 },
+    { ...tx, id: 'txB', merchant_name: 'Uber', amount: 15 },
+  ];
+  const onSuccess = jest.fn();
+  render(
+    <FriendPickerSheet
+      transaction={null}
+      combineTransactions={members}
+      openToken={1}
+      onSuccess={onSuccess}
+    />
+  );
+
+  fireEvent.press(screen.getByLabelText('Sam'));
+  fireEvent.press(screen.getByLabelText('Add split to Splitwise'));
+
+  await waitFor(() => expect(mockCreateExpense).toHaveBeenCalledTimes(1));
+  expect(mockCreateExpense).toHaveBeenCalledWith(
+    expect.objectContaining({ amount: 20, description: 'Starbucks, Uber' })
+  );
+  await waitFor(() => expect(mockInsert).toHaveBeenCalledTimes(2));
+  expect(mockInsert).toHaveBeenCalledWith(
+    expect.objectContaining({ transaction_id: 'txA', splitwise_expense_id: 'expNew', description: 'Starbucks, Uber' })
+  );
+  expect(mockInsert).toHaveBeenCalledWith(
+    expect.objectContaining({ transaction_id: 'txB', splitwise_expense_id: 'expNew' })
+  );
+  expect(markSplit).toHaveBeenCalledWith('txA');
+  expect(markSplit).toHaveBeenCalledWith('txB');
+  expect(onSuccess).toHaveBeenCalledWith(10);
+});
+
+test('combine edit upserts one row per member, reusing the decision id for its own row', async () => {
+  const members: Transaction[] = [
+    { ...tx, id: 'txA', merchant_name: 'Starbucks', amount: 5 },
+    { ...tx, id: 'txB', merchant_name: 'Uber', amount: 15 },
+  ];
+  const onSuccess = jest.fn();
+  render(
+    <FriendPickerSheet
+      transaction={null}
+      combineTransactions={members}
+      mode="edit"
+      editDecision={{ ...decision, transaction_id: 'txA' }}
+      openToken={1}
+      onSuccess={onSuccess}
+    />
+  );
+
+  await waitFor(() => expect(mockGetExpense).toHaveBeenCalled());
+  fireEvent.press(screen.getByLabelText('Add split to Splitwise'));
+
+  await waitFor(() => expect(mockUpdateExpense).toHaveBeenCalledTimes(1));
+  expect(mockUpdateExpense).toHaveBeenCalledWith('exp1', expect.objectContaining({ amount: 20 }));
+  await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(2));
+  expect(mockUpsert).toHaveBeenCalledWith(
+    expect.objectContaining({ id: 'sd1', transaction_id: 'txA', splitwise_expense_id: 'exp1' })
+  );
+  expect(mockUpsert).toHaveBeenCalledWith(
+    expect.objectContaining({ transaction_id: 'txB', splitwise_expense_id: 'exp1' })
+  );
+  expect(onSuccess).toHaveBeenCalledWith(10);
+});
+
+test('single create passes the edited title as the description', async () => {
+  render(
+    <FriendPickerSheet transaction={{ ...tx, status: 'new' }} openToken={1} onSuccess={jest.fn()} />
+  );
+  fireEvent.changeText(screen.getByLabelText('Split title'), 'Groceries');
+  fireEvent.press(screen.getByLabelText('Sam'));
+  fireEvent.press(screen.getByLabelText('Add split to Splitwise'));
+
+  await waitFor(() => expect(mockCreateExpense).toHaveBeenCalledTimes(1));
+  expect(mockCreateExpense).toHaveBeenCalledWith(
+    expect.objectContaining({ description: 'Groceries' })
+  );
+  await waitFor(() =>
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ description: 'Groceries', transaction_id: 'tx1' }))
+  );
 });

--- a/mobile/__tests__/components/HistoryActionSheet.test.tsx
+++ b/mobile/__tests__/components/HistoryActionSheet.test.tsx
@@ -3,17 +3,14 @@ jest.mock('@gorhom/bottom-sheet', () => require('@gorhom/bottom-sheet/mock'));
 
 import { render, fireEvent, screen } from '@testing-library/react-native';
 import { HistoryActionSheet } from '@/components/HistoryActionSheet';
-import { TransactionWithSplit } from '@/lib/types';
+import { HistoryItem } from '@/lib/types';
 
-const tx: TransactionWithSplit = {
+const tx: HistoryItem = {
   id: 'tx1',
   merchant_name: 'Amazon',
   amount: 29.99,
-  currency: 'USD',
   date: '2026-06-10',
   status: 'split',
-  pending: false,
-  created_at: '2026-06-10T10:00:00Z',
   split: { friend_names: ['Sam'], amount_each: 15 },
 };
 

--- a/mobile/__tests__/components/HistoryActionSheet.test.tsx
+++ b/mobile/__tests__/components/HistoryActionSheet.test.tsx
@@ -9,6 +9,7 @@ const tx: HistoryItem = {
   id: 'tx1',
   merchant_name: 'Amazon',
   amount: 29.99,
+  currency: 'USD',
   date: '2026-06-10',
   status: 'split',
   split: { friend_names: ['Sam'], amount_each: 15 },

--- a/mobile/__tests__/components/TransactionRow.test.tsx
+++ b/mobile/__tests__/components/TransactionRow.test.tsx
@@ -1,0 +1,60 @@
+// mobile/__tests__/components/TransactionRow.test.tsx
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const { View } = require('react-native');
+  return ({ children }: { children: React.ReactNode }) => <View>{children}</View>;
+});
+
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react-native';
+import { TransactionRow } from '@/components/TransactionRow';
+import { Transaction } from '@/lib/types';
+
+const tx: Transaction = {
+  id: 'tx1',
+  merchant_name: 'Amazon',
+  amount: 20,
+  currency: 'USD',
+  date: '2026-07-01',
+  status: 'new',
+  pending: false,
+  created_at: '2026-07-01T00:00:00Z',
+};
+
+test('long-press fires onLongPress in normal mode', () => {
+  const onLongPress = jest.fn();
+  render(<TransactionRow transaction={tx} onSkip={jest.fn()} onSplit={jest.fn()} onLongPress={onLongPress} />);
+  fireEvent(screen.getByLabelText('Split Amazon'), 'longPress');
+  expect(onLongPress).toHaveBeenCalled();
+});
+
+test('in select mode with selected=true, the checkbox reflects a checked state', () => {
+  render(
+    <TransactionRow
+      transaction={tx}
+      onSkip={jest.fn()}
+      onSplit={jest.fn()}
+      selectMode
+      selected
+      onToggleSelect={jest.fn()}
+    />
+  );
+  const row = screen.getByLabelText('Select Amazon');
+  expect(row.props.accessibilityState).toEqual({ checked: true });
+});
+
+test('in select mode, tapping the row toggles selection and hides split/skip actions', () => {
+  const onToggleSelect = jest.fn();
+  render(
+    <TransactionRow
+      transaction={tx}
+      onSkip={jest.fn()}
+      onSplit={jest.fn()}
+      selectMode
+      selected={false}
+      onToggleSelect={onToggleSelect}
+    />
+  );
+  expect(screen.queryByLabelText('Split Amazon')).toBeNull();
+  fireEvent.press(screen.getByLabelText('Select Amazon'));
+  expect(onToggleSelect).toHaveBeenCalled();
+});

--- a/mobile/__tests__/lib/db.test.ts
+++ b/mobile/__tests__/lib/db.test.ts
@@ -272,8 +272,23 @@ test('getHistoryTransactions returns single split rows keyed by transaction id',
   expect(items).toHaveLength(1);
   expect(items[0].id).toBe('tx1');
   expect(items[0].merchant_name).toBe('Books');          // description wins
+  expect(items[0].currency).toBe('USD');
   expect(items[0].combined).toBeUndefined();
   expect(items[0].split?.friend_names).toEqual(['Sam']);
+});
+
+test('getHistoryTransactions surfaces a split row missing its expense id (not as skipped)', async () => {
+  mockDb.getFirstAsync.mockResolvedValue({ user_version: 3 });
+  await initDb();
+  mockDb.getAllAsync.mockResolvedValueOnce([
+    { id: 'tx1', merchant_name: 'Amazon', amount: 20, currency: 'USD', date: '2026-07-01', status: 'split', pending: 0, created_at: 'x',
+      splitwise_expense_id: null, description: 'Books', friend_names: '["Sam"]', amount_each: 10 },
+  ]);
+  const items = await getHistoryTransactions();
+  expect(items).toHaveLength(1);
+  expect(items[0].status).toBe('split');
+  expect(items[0].split?.friend_names).toEqual(['Sam']);
+  expect(items[0].combined).toBeUndefined();
 });
 
 test('getHistoryTransactions collapses shared-expense rows into one combined item', async () => {

--- a/mobile/__tests__/lib/db.test.ts
+++ b/mobile/__tests__/lib/db.test.ts
@@ -15,6 +15,7 @@ import {
   deleteSplitDecision,
   pruneOldTransactions,
   deleteAllTransactions,
+  getTransactionsByIds,
 } from '@/lib/db';
 import { PlaidTransaction, SplitDecision } from '@/lib/types';
 
@@ -237,4 +238,25 @@ test('getSplitDecision returns the description', async () => {
   });
   const result = await getSplitDecision('tx1');
   expect(result?.description).toBe('Team lunch');
+});
+
+test('getTransactionsByIds returns empty for no ids without querying', async () => {
+  await initDb();
+  mockDb.getAllAsync.mockClear();
+  const result = await getTransactionsByIds([]);
+  expect(result).toEqual([]);
+  expect(mockDb.getAllAsync).not.toHaveBeenCalled();
+});
+
+test('getTransactionsByIds queries by id list and maps pending', async () => {
+  await initDb();
+  mockDb.getAllAsync.mockResolvedValueOnce([
+    { id: 'tx1', merchant_name: 'A', amount: 5, currency: 'USD', date: '2026-07-01', status: 'split', pending: 1, created_at: '2026-07-01T00:00:00Z' },
+  ]);
+  const result = await getTransactionsByIds(['tx1', 'tx2']);
+  expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+    expect.stringContaining('WHERE id IN (?,?)'),
+    ['tx1', 'tx2']
+  );
+  expect(result[0].pending).toBe(true);
 });

--- a/mobile/__tests__/lib/db.test.ts
+++ b/mobile/__tests__/lib/db.test.ts
@@ -260,3 +260,48 @@ test('getTransactionsByIds queries by id list and maps pending', async () => {
   );
   expect(result[0].pending).toBe(true);
 });
+
+test('getHistoryTransactions returns single split rows keyed by transaction id', async () => {
+  mockDb.getFirstAsync.mockResolvedValue({ user_version: 3 });
+  await initDb();
+  mockDb.getAllAsync.mockResolvedValueOnce([
+    { id: 'tx1', merchant_name: 'Amazon', amount: 20, currency: 'USD', date: '2026-07-01', status: 'split', pending: 0, created_at: 'x',
+      splitwise_expense_id: 'exp1', description: 'Books', friend_names: '["Sam"]', amount_each: 10 },
+  ]);
+  const items = await getHistoryTransactions();
+  expect(items).toHaveLength(1);
+  expect(items[0].id).toBe('tx1');
+  expect(items[0].merchant_name).toBe('Books');          // description wins
+  expect(items[0].combined).toBeUndefined();
+  expect(items[0].split?.friend_names).toEqual(['Sam']);
+});
+
+test('getHistoryTransactions collapses shared-expense rows into one combined item', async () => {
+  mockDb.getFirstAsync.mockResolvedValue({ user_version: 3 });
+  await initDb();
+  mockDb.getAllAsync.mockResolvedValueOnce([
+    { id: 'tx1', merchant_name: 'Amazon', amount: 20, currency: 'USD', date: '2026-07-02', status: 'split', pending: 0, created_at: 'x',
+      splitwise_expense_id: 'expShared', description: 'Trip', friend_names: '["Sam"]', amount_each: 15 },
+    { id: 'tx2', merchant_name: 'Uber', amount: 10, currency: 'USD', date: '2026-07-01', status: 'split', pending: 0, created_at: 'x',
+      splitwise_expense_id: 'expShared', description: 'Trip', friend_names: '["Sam"]', amount_each: 15 },
+  ]);
+  const items = await getHistoryTransactions();
+  expect(items).toHaveLength(1);
+  expect(items[0].id).toBe('expShared');
+  expect(items[0].amount).toBe(30);                        // summed
+  expect(items[0].combined).toEqual({ expense_id: 'expShared', transaction_ids: ['tx1', 'tx2'], count: 2 });
+});
+
+test('getHistoryTransactions keeps skipped rows individual', async () => {
+  mockDb.getFirstAsync.mockResolvedValue({ user_version: 3 });
+  await initDb();
+  mockDb.getAllAsync.mockResolvedValueOnce([
+    { id: 'tx9', merchant_name: 'Netflix', amount: 12, currency: 'USD', date: '2026-07-01', status: 'skipped', pending: 0, created_at: 'x',
+      splitwise_expense_id: null, description: null, friend_names: null, amount_each: null },
+  ]);
+  const items = await getHistoryTransactions();
+  expect(items).toHaveLength(1);
+  expect(items[0].id).toBe('tx9');
+  expect(items[0].status).toBe('skipped');
+  expect(items[0].split).toBeUndefined();
+});

--- a/mobile/__tests__/lib/db.test.ts
+++ b/mobile/__tests__/lib/db.test.ts
@@ -178,3 +178,63 @@ test('deleteSplitDecision deletes by transaction_id', async () => {
     ['tx1']
   );
 });
+
+test('initDb migrates a v1 install by adding both pending and description columns', async () => {
+  mockDb.getFirstAsync.mockResolvedValueOnce({ user_version: 1 });
+  await initDb();
+  expect(mockDb.execAsync).toHaveBeenCalledWith(
+    expect.stringContaining('ALTER TABLE transactions ADD COLUMN pending')
+  );
+  expect(mockDb.execAsync).toHaveBeenCalledWith(
+    expect.stringContaining('ALTER TABLE split_decisions ADD COLUMN description')
+  );
+  expect(mockDb.execAsync).toHaveBeenCalledWith(
+    expect.stringContaining('user_version = 3')
+  );
+});
+
+test('initDb migrates an existing v2 install by adding the description column', async () => {
+  mockDb.getFirstAsync.mockResolvedValueOnce({ user_version: 2 });
+  await initDb();
+  expect(mockDb.execAsync).toHaveBeenCalledWith(
+    expect.stringContaining('ALTER TABLE split_decisions ADD COLUMN description')
+  );
+  expect(mockDb.execAsync).toHaveBeenCalledWith(
+    expect.stringContaining('user_version = 3')
+  );
+});
+
+test('insertSplitDecision persists the description', async () => {
+  await initDb();
+  await insertSplitDecision({
+    id: 'sd1',
+    transaction_id: 'tx1',
+    splitwise_expense_id: 'exp1',
+    friend_ids: ['2'],
+    friend_names: ['Sam'],
+    amount_each: 10,
+    created_at: '2026-07-06T00:00:00Z',
+    description: 'Team lunch',
+  });
+  expect(mockDb.runAsync).toHaveBeenCalledWith(
+    expect.stringContaining('description'),
+    expect.arrayContaining(['sd1', 'tx1', 'exp1', '["2"]', '["Sam"]', 10, '2026-07-06T00:00:00Z', 'Team lunch'])
+  );
+});
+
+test('getSplitDecision returns the description', async () => {
+  mockDb.getFirstAsync.mockResolvedValue({ user_version: 3 });
+  await initDb();
+  mockDb.getFirstAsync.mockResolvedValueOnce({
+    id: 'sd1',
+    transaction_id: 'tx1',
+    splitwise_expense_id: 'exp1',
+    friend_ids: '["2"]',
+    friend_names: '["Sam"]',
+    amount_each: 10,
+    created_at: '2026-07-06T00:00:00Z',
+    description: 'Team lunch',
+  });
+  const result = await getSplitDecision('tx1');
+  expect(result?.description).toBe('Team lunch');
+});

--- a/mobile/__tests__/stores/transactionStore.test.ts
+++ b/mobile/__tests__/stores/transactionStore.test.ts
@@ -172,3 +172,14 @@ test('deleteSplit leaves local state untouched if the Splitwise delete fails', a
   expect(mockDeleteSplitDecision).not.toHaveBeenCalled();
   expect(mockUpdateStatus).not.toHaveBeenCalled();
 });
+
+test('deleteCombinedSplit deletes the expense once and reverts all members', async () => {
+  await useTransactionStore.getState().deleteCombinedSplit(['tx1', 'tx2'], 'expShared');
+
+  expect(mockDeleteExpense).toHaveBeenCalledTimes(1);
+  expect(mockDeleteExpense).toHaveBeenCalledWith('expShared');
+  expect(mockDeleteSplitDecision).toHaveBeenCalledWith('tx1');
+  expect(mockDeleteSplitDecision).toHaveBeenCalledWith('tx2');
+  expect(mockUpdateStatus).toHaveBeenCalledWith('tx1', 'new');
+  expect(mockUpdateStatus).toHaveBeenCalledWith('tx2', 'new');
+});

--- a/mobile/app/(tabs)/history.tsx
+++ b/mobile/app/(tabs)/history.tsx
@@ -4,24 +4,43 @@ import Constants from 'expo-constants';
 import { useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { getHistoryTransactions, getSplitDecision } from '@/lib/db';
-import { TransactionWithSplit, SplitDecision } from '@/lib/types';
+import { getHistoryTransactions, getSplitDecision, getTransactionsByIds } from '@/lib/db';
+import { HistoryItem, SplitDecision, Transaction } from '@/lib/types';
 import { useTransactionStore } from '@/stores/transactionStore';
 import { FriendPickerSheet } from '@/components/FriendPickerSheet';
 import { HistoryActionSheet } from '@/components/HistoryActionSheet';
 import { useToast } from '@/components/ToastProvider';
 import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
 
+// Adapt a single-split HistoryItem back to a Transaction for the picker's
+// single-edit flow. The picker reloads real friend shares/description from the
+// DB via editDecision + getExpense, so the currency default only affects the
+// Splitwise currency_code on re-save (see plan: multi-currency out of scope v1).
+function asTransaction(item: HistoryItem): Transaction {
+  return {
+    id: item.id,
+    merchant_name: item.merchant_name,
+    amount: item.amount,
+    currency: 'USD',
+    date: item.date,
+    status: item.status,
+    pending: false,
+    created_at: item.date,
+  };
+}
+
 export default function HistoryScreen() {
-  const [rows, setRows] = useState<TransactionWithSplit[]>([]);
-  const [selected, setSelected] = useState<TransactionWithSplit | null>(null);
+  const [rows, setRows] = useState<HistoryItem[]>([]);
+  const [selected, setSelected] = useState<HistoryItem | null>(null);
   const [editDecision, setEditDecision] = useState<SplitDecision | null>(null);
+  const [combineTxs, setCombineTxs] = useState<Transaction[] | null>(null);
   const [pickerMode, setPickerMode] = useState<'create' | 'edit'>('create');
   const [pending, setPending] = useState<null | 'picker' | 'action'>(null);
   const [pickerToken, setPickerToken] = useState(0);
   const pickerRef = useRef<BottomSheetModal>(null);
   const actionRef = useRef<BottomSheetModal>(null);
   const deleteSplit = useTransactionStore((s) => s.deleteSplit);
+  const deleteCombinedSplit = useTransactionStore((s) => s.deleteCombinedSplit);
   const toast = useToast();
 
   const refreshHistory = useCallback(() => {
@@ -46,16 +65,17 @@ export default function HistoryScreen() {
     }
   }, [pending]);
 
-  function handleRowPress(item: TransactionWithSplit) {
+  function handleRowPress(item: HistoryItem) {
     if (item.status === 'skipped') {
       // Split a previously-skipped transaction (create mode).
       setEditDecision(null);
+      setCombineTxs(null);
       setPickerMode('create');
       setSelected(item);
       setPickerToken((t) => t + 1);
       setPending('picker');
     } else {
-      // Split row: offer edit/delete.
+      // Split row (single or combined): offer edit/delete.
       setSelected(item);
       setPending('action');
     }
@@ -63,12 +83,30 @@ export default function HistoryScreen() {
 
   async function handleEdit() {
     if (!selected) return;
+    if (selected.combined) {
+      // Combined split: load all member transactions + the shared decision
+      // (any member's row carries the shared expense id, friends, description).
+      const members = await getTransactionsByIds(selected.combined.transaction_ids);
+      const decision = await getSplitDecision(selected.combined.transaction_ids[0]);
+      if (!decision || members.length === 0) {
+        toast.show('Could not load this split. Please try again.', 'error');
+        return;
+      }
+      actionRef.current?.dismiss();
+      setCombineTxs(members);
+      setEditDecision(decision);
+      setPickerMode('edit');
+      setPickerToken((t) => t + 1);
+      setPending('picker');
+      return;
+    }
     const decision = await getSplitDecision(selected.id);
     if (!decision) {
       toast.show('Could not load this split. Please try again.', 'error');
       return;
     }
     actionRef.current?.dismiss();
+    setCombineTxs(null);
     setEditDecision(decision);
     setPickerMode('edit');
     setPickerToken((t) => t + 1);
@@ -77,24 +115,29 @@ export default function HistoryScreen() {
 
   function handleDelete() {
     if (!selected) return;
-    const tx = selected;
+    const item = selected;
     actionRef.current?.dismiss();
+    const label = item.combined ? `${item.combined.count} transactions` : item.merchant_name;
     Alert.alert(
       'Delete split?',
-      `This removes the Splitwise expense for ${tx.merchant_name} and moves it back to your transactions.`,
+      `This removes the Splitwise expense for ${label} and moves ${item.combined ? 'them' : 'it'} back to your transactions.`,
       [
         { text: 'Cancel', style: 'cancel' },
         {
           text: 'Delete',
           style: 'destructive',
           onPress: async () => {
-            const decision = await getSplitDecision(tx.id);
-            if (!decision) {
-              toast.show('Could not load this split. Please try again.', 'error');
-              return;
-            }
             try {
-              await deleteSplit(tx.id, decision.splitwise_expense_id);
+              if (item.combined) {
+                await deleteCombinedSplit(item.combined.transaction_ids, item.combined.expense_id);
+              } else {
+                const decision = await getSplitDecision(item.id);
+                if (!decision) {
+                  toast.show('Could not load this split. Please try again.', 'error');
+                  return;
+                }
+                await deleteSplit(item.id, decision.splitwise_expense_id);
+              }
               toast.show('Split deleted', 'success');
               refreshHistory();
             } catch {
@@ -135,7 +178,8 @@ export default function HistoryScreen() {
 
       <FriendPickerSheet
         ref={pickerRef}
-        transaction={selected}
+        transaction={combineTxs ? null : selected ? asTransaction(selected) : null}
+        combineTransactions={combineTxs ?? undefined}
         mode={pickerMode}
         editDecision={editDecision}
         openToken={pickerToken}
@@ -165,7 +209,7 @@ function EmptyState() {
   );
 }
 
-function HistoryRow({ item, onPress }: { item: TransactionWithSplit; onPress: () => void }) {
+function HistoryRow({ item, onPress }: { item: HistoryItem; onPress: () => void }) {
   const date = new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   const isSplit = item.status === 'split' && item.split;
   const initial = (item.merchant_name ?? '?')[0].toUpperCase();
@@ -187,7 +231,10 @@ function HistoryRow({ item, onPress }: { item: TransactionWithSplit; onPress: ()
       </View>
       <View style={styles.info}>
         <Text style={styles.merchant} numberOfLines={1}>{item.merchant_name}</Text>
-        <Text style={styles.date}>{date}</Text>
+        <Text style={styles.date}>
+          {date}
+          {item.combined ? ` · ${item.combined.count} transactions` : ''}
+        </Text>
         {isSplit ? (
           <View style={styles.splitBadge}>
             <Ionicons name="people-outline" size={11} color={Colors.success} style={{ marginRight: 3 }} />

--- a/mobile/app/(tabs)/history.tsx
+++ b/mobile/app/(tabs)/history.tsx
@@ -13,15 +13,15 @@ import { useToast } from '@/components/ToastProvider';
 import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
 
 // Adapt a single-split HistoryItem back to a Transaction for the picker's
-// single-edit flow. The picker reloads real friend shares/description from the
-// DB via editDecision + getExpense, so the currency default only affects the
-// Splitwise currency_code on re-save (see plan: multi-currency out of scope v1).
+// single-edit / split-from-skipped flows. Carries the real currency so re-saving
+// preserves the Splitwise currency_code. pending/created_at don't affect the
+// expense, so safe defaults are fine.
 function asTransaction(item: HistoryItem): Transaction {
   return {
     id: item.id,
     merchant_name: item.merchant_name,
     amount: item.amount,
-    currency: 'USD',
+    currency: item.currency,
     date: item.date,
     status: item.status,
     pending: false,
@@ -86,8 +86,10 @@ export default function HistoryScreen() {
     if (selected.combined) {
       // Combined split: load all member transactions + the shared decision
       // (any member's row carries the shared expense id, friends, description).
-      const members = await getTransactionsByIds(selected.combined.transaction_ids);
-      const decision = await getSplitDecision(selected.combined.transaction_ids[0]);
+      const [members, decision] = await Promise.all([
+        getTransactionsByIds(selected.combined.transaction_ids),
+        getSplitDecision(selected.combined.transaction_ids[0]),
+      ]);
       if (!decision || members.length === 0) {
         toast.show('Could not load this split. Please try again.', 'error');
         return;

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { FlatList, RefreshControl, StatusBar, StyleSheet, Text, View } from 'react-native';
+import { FlatList, Pressable, RefreshControl, StatusBar, StyleSheet, Text, View } from 'react-native';
 import Constants from 'expo-constants';
 import NetInfo from '@react-native-community/netinfo';
 import { useRouter } from 'expo-router';
@@ -13,7 +13,7 @@ import { FriendPickerSheet } from '@/components/FriendPickerSheet';
 import { useToast } from '@/components/ToastProvider';
 import { Transaction } from '@/lib/types';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { Colors, Spacing, Radius } from '@/lib/theme';
+import { Colors, Spacing, Radius, Shadow } from '@/lib/theme';
 
 export default function NewTransactionsScreen() {
   const router = useRouter();
@@ -24,6 +24,10 @@ export default function NewTransactionsScreen() {
   const [selected, setSelected] = useState<Transaction | null>(null);
   const sheetRef = useRef<BottomSheetModal>(null);
   const toast = useToast();
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [combineTxs, setCombineTxs] = useState<Transaction[] | null>(null);
+  const [pickerToken, setPickerToken] = useState(0);
 
   useEffect(() => {
     load();
@@ -33,12 +37,42 @@ export default function NewTransactionsScreen() {
   }, []);
 
   function openSheet(tx: Transaction) {
+    setCombineTxs(null);
     setSelected(tx);
+    setPickerToken((t) => t + 1);
+    sheetRef.current?.present();
+  }
+
+  function enterSelect(tx: Transaction) {
+    setSelectMode(true);
+    setSelectedIds(new Set([tx.id]));
+  }
+
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }
+
+  function cancelSelect() {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }
+
+  function openCombine() {
+    const members = transactions.filter((t) => selectedIds.has(t.id));
+    if (members.length === 0) return;
+    setSelected(null);
+    setCombineTxs(members);
+    setPickerToken((t) => t + 1);
     sheetRef.current?.present();
   }
 
   function handleSplitSuccess(amountEach: number) {
     sheetRef.current?.dismiss();
+    cancelSelect();
     toast.show(`Added! Others owe you $${amountEach.toFixed(2)}`, 'success');
   }
 
@@ -81,6 +115,7 @@ export default function NewTransactionsScreen() {
           data={transactions}
           keyExtractor={(t) => t.id}
           contentContainerStyle={styles.list}
+          extraData={{ selectMode, selectedIds }}
           refreshControl={
             <RefreshControl
               refreshing={isLoading}
@@ -93,6 +128,10 @@ export default function NewTransactionsScreen() {
               transaction={item}
               onSkip={() => skip(item.id)}
               onSplit={() => openSheet(item)}
+              onLongPress={() => enterSelect(item)}
+              selectMode={selectMode}
+              selected={selectedIds.has(item.id)}
+              onToggleSelect={() => toggleSelect(item.id)}
             />
           )}
         />
@@ -101,8 +140,32 @@ export default function NewTransactionsScreen() {
       <FriendPickerSheet
         ref={sheetRef}
         transaction={selected}
+        combineTransactions={combineTxs ?? undefined}
+        openToken={pickerToken}
         onSuccess={handleSplitSuccess}
       />
+      {selectMode && (
+        <View style={styles.selectBar}>
+          <Pressable
+            style={styles.selectCancel}
+            onPress={cancelSelect}
+            accessibilityRole="button"
+            accessibilityLabel="Cancel selection"
+          >
+            <Text style={styles.selectCancelText}>Cancel</Text>
+          </Pressable>
+          <Pressable
+            style={[styles.selectSplit, selectedIds.size === 0 && styles.selectSplitDisabled]}
+            onPress={openCombine}
+            disabled={selectedIds.size === 0}
+            accessibilityRole="button"
+            accessibilityLabel="Split selected together"
+          >
+            <Ionicons name="people-outline" size={16} color={Colors.textInverse} style={{ marginRight: 6 }} />
+            <Text style={styles.selectSplitText}>Split together ({selectedIds.size})</Text>
+          </Pressable>
+        </View>
+      )}
     </View>
   );
 }
@@ -228,4 +291,38 @@ const styles = StyleSheet.create({
     borderRadius: Radius.sm,
     backgroundColor: Colors.surfaceMuted,
   },
+
+  selectBar: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    flexDirection: 'row',
+    gap: Spacing.md,
+    padding: Spacing.lg,
+    backgroundColor: Colors.surface,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+  },
+  selectCancel: {
+    paddingVertical: 16,
+    paddingHorizontal: Spacing.xl,
+    borderRadius: Radius.lg,
+    backgroundColor: Colors.surfaceMuted,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  selectCancelText: { fontSize: 15, fontWeight: '600', color: Colors.textSecondary },
+  selectSplit: {
+    flex: 1,
+    flexDirection: 'row',
+    paddingVertical: 16,
+    borderRadius: Radius.lg,
+    backgroundColor: Colors.primary,
+    justifyContent: 'center',
+    alignItems: 'center',
+    ...Shadow.sm,
+  },
+  selectSplitDisabled: { backgroundColor: Colors.surfaceMuted },
+  selectSplitText: { fontSize: 15, fontWeight: '700', color: Colors.textInverse },
 });

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, Pressable, RefreshControl, StatusBar, StyleSheet, Text, View } from 'react-native';
 import Constants from 'expo-constants';
 import NetInfo from '@react-native-community/netinfo';
@@ -64,6 +64,11 @@ export default function NewTransactionsScreen() {
   function openCombine() {
     const members = transactions.filter((t) => selectedIds.has(t.id));
     if (members.length === 0) return;
+    // A single Splitwise expense has one currency; block combining across currencies.
+    if (new Set(members.map((t) => t.currency)).size > 1) {
+      toast.show('Select transactions in the same currency to combine.', 'error');
+      return;
+    }
     setSelected(null);
     setCombineTxs(members);
     setPickerToken((t) => t + 1);
@@ -81,6 +86,7 @@ export default function NewTransactionsScreen() {
   }
 
   const isEmptyAndLoaded = !isLoading && transactions.length === 0;
+  const listExtraData = useMemo(() => ({ selectMode, selectedIds }), [selectMode, selectedIds]);
 
   return (
     <View style={[styles.root, { paddingTop: topInset }]}>
@@ -115,7 +121,7 @@ export default function NewTransactionsScreen() {
           data={transactions}
           keyExtractor={(t) => t.id}
           contentContainerStyle={styles.list}
-          extraData={{ selectMode, selectedIds }}
+          extraData={listExtraData}
           refreshControl={
             <RefreshControl
               refreshing={isLoading}

--- a/mobile/components/FriendPickerSheet.tsx
+++ b/mobile/components/FriendPickerSheet.tsx
@@ -249,7 +249,10 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
           ...shares,
         });
 
+        // Persist every member row before flipping any status, so a mid-loop DB
+        // failure never leaves the list half-marked (some members removed, some not).
         const ts = Date.now();
+        const createdAt = new Date().toISOString();
         for (const t of members) {
           await insertWithRetry({
             id: `${t.id}-${ts}`,
@@ -258,9 +261,11 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
             friend_ids: friendIds,
             friend_names: friendNames,
             amount_each,
-            created_at: new Date().toISOString(),
+            created_at: createdAt,
             description: desc,
           });
+        }
+        for (const t of members) {
           await markSplit(t.id);
         }
         onSuccess(amount_each);
@@ -275,6 +280,9 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       }
     }
 
+    const titleColor = merchantColor(title || '?');
+    const titleInitial = (title || '?')[0].toUpperCase();
+
     return (
       <BottomSheetModal
         ref={ref}
@@ -288,10 +296,8 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
         <BottomSheetView style={styles.container}>
           {/* Title + total */}
           <View style={styles.txSummary}>
-            <View style={[styles.txAvatar, { backgroundColor: merchantColor(title || '?') + '18' }]}>
-              <Text style={[styles.txAvatarText, { color: merchantColor(title || '?') }]}>
-                {(title || '?')[0].toUpperCase()}
-              </Text>
+            <View style={[styles.txAvatar, { backgroundColor: titleColor + '18' }]}>
+              <Text style={[styles.txAvatarText, { color: titleColor }]}>{titleInitial}</Text>
             </View>
             <View style={styles.txInfo}>
               <BottomSheetTextInput
@@ -604,7 +610,6 @@ const styles = StyleSheet.create({
   },
   txAvatarText: { fontSize: 20, fontWeight: '700' },
   txInfo: { flex: 1 },
-  txMerchant: { fontSize: 17, fontWeight: '700', color: Colors.textPrimary },
   titleInput: {
     fontSize: 17,
     fontWeight: '700',

--- a/mobile/components/FriendPickerSheet.tsx
+++ b/mobile/components/FriendPickerSheet.tsx
@@ -26,8 +26,15 @@ import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
 type SplitMode = 'equal' | 'custom';
 const STEP = 0.5;
 
+function summarizeMerchants(members: Transaction[]): string {
+  const names = members.map((m) => m.merchant_name);
+  if (names.length <= 2) return names.join(', ');
+  return `${names[0]}, ${names[1]} +${names.length - 2}`;
+}
+
 interface Props {
   transaction: Transaction | null;
+  combineTransactions?: Transaction[]; // when present, this is a combined split
   mode?: 'create' | 'edit';
   editDecision?: SplitDecision | null;
   // Changes each time the host presents the sheet, so the pre-fill effect
@@ -38,10 +45,25 @@ interface Props {
 }
 
 export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
-  ({ transaction, mode = 'create', editDecision, openToken, onSuccess }, ref) => {
+  ({ transaction, combineTransactions, mode = 'create', editDecision, openToken, onSuccess }, ref) => {
     const { friends, isLoading } = useFriendStore();
     const user_id = useAuthStore((s) => s.user_id);
     const markSplit = useTransactionStore((s) => s.markSplit);
+
+    const members = useMemo(
+      () =>
+        combineTransactions && combineTransactions.length > 0
+          ? combineTransactions
+          : transaction
+          ? [transaction]
+          : [],
+      [combineTransactions, transaction]
+    );
+    const isCombine = (combineTransactions?.length ?? 0) > 0;
+    const totalAmount = useMemo(() => members.reduce((s, t) => s + t.amount, 0), [members]);
+    const currency = members[0]?.currency ?? 'USD';
+
+    const [title, setTitle] = useState('');
 
     const [selected, setSelected] = useState<Set<string>>(new Set());
     const [query, setQuery] = useState('');
@@ -89,6 +111,19 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [mode, editDecision?.transaction_id, openToken]);
 
+    // Pre-fill the title on every open: stored description for edits, a merchant
+    // summary for combined splits, otherwise the single transaction's merchant.
+    useEffect(() => {
+      if (mode === 'edit' && editDecision) {
+        setTitle(editDecision.description || members[0]?.merchant_name || '');
+      } else if (isCombine) {
+        setTitle(summarizeMerchants(members));
+      } else {
+        setTitle(members[0]?.merchant_name || '');
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [openToken]);
+
     const filtered = useMemo(() => {
       const q = query.trim().toLowerCase();
       return q ? friends.filter((f) => f.display_name.toLowerCase().includes(q)) : friends;
@@ -99,9 +134,9 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       [friends, selected]
     );
 
-    if (!transaction) return null;
+    if (members.length === 0) return null;
 
-    const totalCents = Math.round(transaction.amount * 100);
+    const totalCents = Math.round(totalAmount * 100);
     const n = selected.size + 1;
     const equalShareCents = selected.size > 0 ? Math.floor(totalCents / n) : 0;
 
@@ -115,7 +150,7 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
 
     const ownerShareCents = totalCents - friendTotalCents;
     const isOverBudget = ownerShareCents < -1;
-    const ctaDisabled = selected.size === 0 || submitting || isOverBudget;
+    const ctaDisabled = selected.size === 0 || submitting || isOverBudget || title.trim() === '';
 
     // Stable so memoized EqualRows only re-render when their own selection flips.
     const toggle = useCallback((id: string) => {
@@ -148,67 +183,86 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       setCustomAmounts((prev) => ({ ...prev, [id]: value }));
     }
 
+    async function insertWithRetry(decision: SplitDecision) {
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+          await insertSplitDecision(decision);
+          return;
+        } catch {
+          if (attempt === 3) throw new Error('DB_WRITE_FAILED');
+        }
+      }
+    }
+
     async function handleAddToSplitwise() {
       if (ctaDisabled) return;
       setSubmitting(true);
+      const friendIds = selectedFriends.map((f) => f.id);
+      const friendNames = selectedFriends.map((f) => f.display_name);
+      const desc = title.trim();
+      const shares = splitMode === 'custom' ? { friendShares: customAmounts } : {};
       try {
         if (mode === 'edit' && editDecision) {
           const { amount_each } = await updateExpense(editDecision.splitwise_expense_id, {
-            amount: transaction!.amount,
-            description: transaction!.merchant_name,
-            currency: transaction!.currency,
+            amount: totalAmount,
+            description: desc,
+            currency,
             currentUserId: user_id!,
-            friendIds: selectedFriends.map((f) => f.id),
-            ...(splitMode === 'custom' && { friendShares: customAmounts }),
+            friendIds,
+            ...shares,
           });
-          await upsertSplitDecision({
-            id: editDecision.id,
-            transaction_id: transaction!.id,
-            splitwise_expense_id: editDecision.splitwise_expense_id,
-            friend_ids: selectedFriends.map((f) => f.id),
-            friend_names: selectedFriends.map((f) => f.display_name),
-            amount_each,
-            created_at: editDecision.created_at,
-          });
+          for (const t of members) {
+            await upsertSplitDecision({
+              // Reuse the loaded decision's id for its own row; other members
+              // conflict on transaction_id so their generated id is ignored.
+              id: t.id === editDecision.transaction_id ? editDecision.id : `${t.id}-${Date.now()}`,
+              transaction_id: t.id,
+              splitwise_expense_id: editDecision.splitwise_expense_id,
+              friend_ids: friendIds,
+              friend_names: friendNames,
+              amount_each,
+              created_at: editDecision.created_at,
+              description: desc,
+            });
+          }
           onSuccess(amount_each);
           return;
         }
 
-        const existing = await getSplitDecision(transaction!.id);
-        if (existing) {
-          await updateTransactionStatus(transaction!.id, 'split');
-          await markSplit(transaction!.id);
-          onSuccess(existing.amount_each);
-          return;
-        }
-
-        const { expense_id, amount_each } = await createExpense({
-          amount: transaction!.amount,
-          description: transaction!.merchant_name,
-          currency: transaction!.currency,
-          currentUserId: user_id!,
-          friendIds: selectedFriends.map((f) => f.id),
-          ...(splitMode === 'custom' && { friendShares: customAmounts }),
-        });
-
-        for (let attempt = 1; attempt <= 3; attempt++) {
-          try {
-            await insertSplitDecision({
-              id: `${transaction!.id}-${Date.now()}`,
-              transaction_id: transaction!.id,
-              splitwise_expense_id: expense_id,
-              friend_ids: selectedFriends.map((f) => f.id),
-              friend_names: selectedFriends.map((f) => f.display_name),
-              amount_each,
-              created_at: new Date().toISOString(),
-            });
-            break;
-          } catch {
-            if (attempt === 3) throw new Error('DB_WRITE_FAILED');
+        // Create. Idempotency check only applies to a single transaction.
+        if (!isCombine) {
+          const existing = await getSplitDecision(members[0].id);
+          if (existing) {
+            await updateTransactionStatus(members[0].id, 'split');
+            await markSplit(members[0].id);
+            onSuccess(existing.amount_each);
+            return;
           }
         }
 
-        await markSplit(transaction!.id);
+        const { expense_id, amount_each } = await createExpense({
+          amount: totalAmount,
+          description: desc,
+          currency,
+          currentUserId: user_id!,
+          friendIds,
+          ...shares,
+        });
+
+        const ts = Date.now();
+        for (const t of members) {
+          await insertWithRetry({
+            id: `${t.id}-${ts}`,
+            transaction_id: t.id,
+            splitwise_expense_id: expense_id,
+            friend_ids: friendIds,
+            friend_names: friendNames,
+            amount_each,
+            created_at: new Date().toISOString(),
+            description: desc,
+          });
+          await markSplit(t.id);
+        }
         onSuccess(amount_each);
       } catch (err) {
         if (err instanceof SplitwiseAuthError) {
@@ -217,15 +271,9 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
           toast.show('Failed to add expense. Please try again.', 'error');
         }
       } finally {
-        // Re-enable the CTA on every path. The sheet stays mounted (History
-        // reuses it across actions), so a stuck `submitting` would block the
-        // next edit/split.
         setSubmitting(false);
       }
     }
-
-    const merchantInitial = (transaction.merchant_name ?? '?')[0].toUpperCase();
-    const merchantBg = merchantColor(transaction.merchant_name ?? '?');
 
     return (
       <BottomSheetModal
@@ -238,16 +286,24 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
         keyboardBlurBehavior="restore"
       >
         <BottomSheetView style={styles.container}>
-          {/* Transaction summary */}
+          {/* Title + total */}
           <View style={styles.txSummary}>
-            <View style={[styles.txAvatar, { backgroundColor: merchantBg + '18' }]}>
-              <Text style={[styles.txAvatarText, { color: merchantBg }]}>{merchantInitial}</Text>
+            <View style={[styles.txAvatar, { backgroundColor: merchantColor(title || '?') + '18' }]}>
+              <Text style={[styles.txAvatarText, { color: merchantColor(title || '?') }]}>
+                {(title || '?')[0].toUpperCase()}
+              </Text>
             </View>
             <View style={styles.txInfo}>
-              <Text style={styles.txMerchant} numberOfLines={1}>
-                {transaction.merchant_name}
-              </Text>
-              <Text style={styles.txTotal}>${transaction.amount.toFixed(2)}</Text>
+              <BottomSheetTextInput
+                style={styles.titleInput}
+                value={title}
+                onChangeText={setTitle}
+                placeholder="Split title"
+                placeholderTextColor={Colors.textTertiary}
+                accessibilityLabel="Split title"
+                returnKeyType="done"
+              />
+              <Text style={styles.txTotal}>${totalAmount.toFixed(2)}</Text>
             </View>
           </View>
 
@@ -549,6 +605,12 @@ const styles = StyleSheet.create({
   txAvatarText: { fontSize: 20, fontWeight: '700' },
   txInfo: { flex: 1 },
   txMerchant: { fontSize: 17, fontWeight: '700', color: Colors.textPrimary },
+  titleInput: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    paddingVertical: 2,
+  },
   txTotal: {
     fontSize: 24,
     fontWeight: '800',

--- a/mobile/components/HistoryActionSheet.tsx
+++ b/mobile/components/HistoryActionSheet.tsx
@@ -3,11 +3,11 @@ import { forwardRef } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
 import { Ionicons } from '@expo/vector-icons';
-import { TransactionWithSplit } from '@/lib/types';
+import { HistoryItem } from '@/lib/types';
 import { Colors, Radius, Spacing, merchantColor } from '@/lib/theme';
 
 interface Props {
-  transaction: TransactionWithSplit | null;
+  transaction: HistoryItem | null;
   onEdit: () => void;
   onDelete: () => void;
 }

--- a/mobile/components/TransactionRow.tsx
+++ b/mobile/components/TransactionRow.tsx
@@ -9,9 +9,13 @@ interface Props {
   transaction: Transaction;
   onSkip: () => void;
   onSplit: () => void;
+  onLongPress?: () => void;
+  selectMode?: boolean;
+  selected?: boolean;
+  onToggleSelect?: () => void;
 }
 
-export function TransactionRow({ transaction, onSkip, onSplit }: Props) {
+export function TransactionRow({ transaction, onSkip, onSplit, onLongPress, selectMode, selected, onToggleSelect }: Props) {
   const amount = `$${transaction.amount.toFixed(2)}`;
   const date = new Date(transaction.date).toLocaleDateString('en-US', {
     month: 'short',
@@ -19,6 +23,30 @@ export function TransactionRow({ transaction, onSkip, onSplit }: Props) {
   });
   const initial = (transaction.merchant_name ?? '?')[0].toUpperCase();
   const avatarBg = merchantColor(transaction.merchant_name ?? '?');
+
+  if (selectMode) {
+    return (
+      <Pressable
+        style={[styles.card, selected && styles.cardSelected]}
+        onPress={onToggleSelect}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: !!selected }}
+        accessibilityLabel={`Select ${transaction.merchant_name}`}
+      >
+        <View style={[styles.checkbox, selected && styles.checkboxSelected]}>
+          {selected && <Ionicons name="checkmark" size={14} color={Colors.textInverse} />}
+        </View>
+        <View style={[styles.avatar, { backgroundColor: avatarBg + '18' }]}>
+          <Text style={[styles.avatarText, { color: avatarBg }]}>{initial}</Text>
+        </View>
+        <View style={styles.info}>
+          <Text style={styles.merchant} numberOfLines={1}>{transaction.merchant_name}</Text>
+          <Text style={styles.date}>{date}</Text>
+        </View>
+        <Text style={styles.amount}>{amount}</Text>
+      </Pressable>
+    );
+  }
 
   const renderSkipUnderlay = () => (
     <Pressable
@@ -42,7 +70,7 @@ export function TransactionRow({ transaction, onSkip, onSplit }: Props) {
       leftThreshold={72}
       friction={1.5}
     >
-      <View style={styles.card}>
+      <Pressable style={styles.card} onLongPress={onLongPress} delayLongPress={300}>
         {/* Merchant avatar */}
         <View style={[styles.avatar, { backgroundColor: avatarBg + '18' }]}>
           <Text style={[styles.avatarText, { color: avatarBg }]}>{initial}</Text>
@@ -77,6 +105,8 @@ export function TransactionRow({ transaction, onSkip, onSplit }: Props) {
           <Pressable
             style={({ pressed }) => [styles.btn, styles.splitBtn, pressed && styles.splitBtnPressed]}
             onPress={onSplit}
+            onLongPress={onLongPress}
+            delayLongPress={300}
             accessibilityRole="button"
             accessibilityLabel={`Split ${transaction.merchant_name}`}
           >
@@ -84,7 +114,7 @@ export function TransactionRow({ transaction, onSkip, onSplit }: Props) {
             <Text style={styles.splitText}>Split</Text>
           </Pressable>
         </View>
-      </View>
+      </Pressable>
     </ReanimatedSwipeable>
   );
 }
@@ -177,4 +207,17 @@ const styles = StyleSheet.create({
     color: Colors.textInverse,
     fontWeight: '600',
   },
+  cardSelected: { backgroundColor: Colors.primaryMuted },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: Radius.sm,
+    borderWidth: 1.5,
+    borderColor: Colors.border,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.surface,
+    marginRight: Spacing.md,
+  },
+  checkboxSelected: { backgroundColor: Colors.primary, borderColor: Colors.primary },
 });

--- a/mobile/lib/db.ts
+++ b/mobile/lib/db.ts
@@ -33,16 +33,20 @@ export async function initDb(): Promise<void> {
         friend_ids TEXT,
         friend_names TEXT,
         amount_each REAL,
-        created_at TEXT
+        created_at TEXT,
+        description TEXT
       );
-      PRAGMA user_version = 2;
-    `);
-  } else if (version < 2) {
-    await _db.execAsync(`
-      ALTER TABLE transactions ADD COLUMN pending INTEGER DEFAULT 0;
-      PRAGMA user_version = 2;
     `);
   }
+  if (version >= 1 && version < 2) {
+    await _db.execAsync(`ALTER TABLE transactions ADD COLUMN pending INTEGER DEFAULT 0;`);
+  }
+  if (version >= 1 && version < 3) {
+    await _db.execAsync(`ALTER TABLE split_decisions ADD COLUMN description TEXT;`);
+  }
+  // NOTE: keep this stamp in sync with the highest migration version above.
+  // When adding a new `version < N` block, bump this to N.
+  await _db.execAsync(`PRAGMA user_version = 3;`);
 }
 
 export async function getNewTransactions(): Promise<Transaction[]> {
@@ -123,6 +127,7 @@ export async function getSplitDecision(transactionId: string): Promise<SplitDeci
     friend_names: string;
     amount_each: number;
     created_at: string;
+    description: string | null;
   }>(
     `SELECT * FROM split_decisions WHERE transaction_id = ?`,
     [transactionId]
@@ -132,6 +137,7 @@ export async function getSplitDecision(transactionId: string): Promise<SplitDeci
     ...row,
     friend_ids: JSON.parse(row.friend_ids),
     friend_names: JSON.parse(row.friend_names),
+    description: row.description ?? undefined,
   };
 }
 
@@ -139,8 +145,8 @@ export async function insertSplitDecision(
   decision: SplitDecision
 ): Promise<void> {
   await db().runAsync(
-    `INSERT INTO split_decisions (id, transaction_id, splitwise_expense_id, friend_ids, friend_names, amount_each, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO split_decisions (id, transaction_id, splitwise_expense_id, friend_ids, friend_names, amount_each, created_at, description)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       decision.id,
       decision.transaction_id,
@@ -149,19 +155,21 @@ export async function insertSplitDecision(
       JSON.stringify(decision.friend_names),
       decision.amount_each,
       decision.created_at,
+      decision.description ?? null,
     ]
   );
 }
 
 export async function upsertSplitDecision(decision: SplitDecision): Promise<void> {
   await db().runAsync(
-    `INSERT INTO split_decisions (id, transaction_id, splitwise_expense_id, friend_ids, friend_names, amount_each, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
+    `INSERT INTO split_decisions (id, transaction_id, splitwise_expense_id, friend_ids, friend_names, amount_each, created_at, description)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(transaction_id) DO UPDATE SET
        splitwise_expense_id = excluded.splitwise_expense_id,
        friend_ids = excluded.friend_ids,
        friend_names = excluded.friend_names,
-       amount_each = excluded.amount_each`,
+       amount_each = excluded.amount_each,
+       description = excluded.description`,
     [
       decision.id,
       decision.transaction_id,
@@ -170,6 +178,7 @@ export async function upsertSplitDecision(decision: SplitDecision): Promise<void
       JSON.stringify(decision.friend_names),
       decision.amount_each,
       decision.created_at,
+      decision.description ?? null,
     ]
   );
 }

--- a/mobile/lib/db.ts
+++ b/mobile/lib/db.ts
@@ -1,6 +1,6 @@
 // mobile/lib/db.ts
 import * as SQLite from 'expo-sqlite';
-import { Transaction, TransactionWithSplit, PlaidTransaction, SplitDecision, TransactionStatus } from '@/lib/types';
+import { Transaction, TransactionWithSplit, PlaidTransaction, SplitDecision, TransactionStatus, HistoryItem } from '@/lib/types';
 
 let _db: SQLite.SQLiteDatabase | null = null;
 
@@ -67,27 +67,72 @@ export async function getTransactionsByIds(ids: string[]): Promise<Transaction[]
   return rows.map((r) => ({ ...r, pending: r.pending === 1 }));
 }
 
-export async function getHistoryTransactions(): Promise<TransactionWithSplit[]> {
+export async function getHistoryTransactions(): Promise<HistoryItem[]> {
   const rows = await db().getAllAsync<Transaction & {
+    splitwise_expense_id: string | null;
+    description: string | null;
     friend_names: string | null;
     amount_each: number | null;
   }>(
-    `SELECT t.*, s.friend_names, s.amount_each
+    `SELECT t.*, s.splitwise_expense_id, s.description, s.friend_names, s.amount_each
      FROM transactions t
      LEFT JOIN split_decisions s ON s.transaction_id = t.id
      WHERE t.status IN ('split','skipped')
      ORDER BY t.date DESC`,
     []
   );
-  return rows.map((r) => ({
-    ...r,
-    split: r.friend_names
-      ? {
-          friend_names: JSON.parse(r.friend_names),
-          amount_each: r.amount_each!,
-        }
-      : undefined,
-  }));
+
+  const items: HistoryItem[] = [];
+  // Track split groups by expense id so multiple member transactions collapse
+  // into one item. _txIds is stripped before returning.
+  const groups = new Map<string, HistoryItem & { _txIds: string[] }>();
+
+  for (const r of rows) {
+    const title = r.description ?? r.merchant_name;
+    if (r.status === 'split' && r.splitwise_expense_id) {
+      const key = r.splitwise_expense_id;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.amount += r.amount;
+        existing._txIds.push(r.id);
+      } else {
+        const item: HistoryItem & { _txIds: string[] } = {
+          id: r.id,
+          merchant_name: title,
+          amount: r.amount,
+          date: r.date,
+          status: 'split',
+          split: {
+            friend_names: r.friend_names ? JSON.parse(r.friend_names) : [],
+            amount_each: r.amount_each ?? 0,
+          },
+          _txIds: [r.id],
+        };
+        groups.set(key, item);
+        items.push(item);
+      }
+    } else {
+      items.push({
+        id: r.id,
+        merchant_name: title,
+        amount: r.amount,
+        date: r.date,
+        status: r.status,
+      });
+    }
+  }
+
+  // Finalize: combined groups (>1 member) expose expense/member metadata and use
+  // the expense id as the row key; single-member groups stay keyed by tx id.
+  for (const [expenseId, g] of groups.entries()) {
+    if (g._txIds.length > 1) {
+      g.combined = { expense_id: expenseId, transaction_ids: g._txIds, count: g._txIds.length };
+      g.id = expenseId;
+    }
+    delete (g as { _txIds?: string[] })._txIds;
+  }
+
+  return items;
 }
 
 export async function upsertTransactions(txs: PlaidTransaction[]): Promise<void> {

--- a/mobile/lib/db.ts
+++ b/mobile/lib/db.ts
@@ -57,6 +57,16 @@ export async function getNewTransactions(): Promise<Transaction[]> {
   return rows.map((r) => ({ ...r, pending: r.pending === 1 }));
 }
 
+export async function getTransactionsByIds(ids: string[]): Promise<Transaction[]> {
+  if (ids.length === 0) return [];
+  const placeholders = ids.map(() => '?').join(',');
+  const rows = await db().getAllAsync<Omit<Transaction, 'pending'> & { pending: number }>(
+    `SELECT * FROM transactions WHERE id IN (${placeholders})`,
+    ids
+  );
+  return rows.map((r) => ({ ...r, pending: r.pending === 1 }));
+}
+
 export async function getHistoryTransactions(): Promise<TransactionWithSplit[]> {
   const rows = await db().getAllAsync<Transaction & {
     friend_names: string | null;

--- a/mobile/lib/db.ts
+++ b/mobile/lib/db.ts
@@ -1,6 +1,6 @@
 // mobile/lib/db.ts
 import * as SQLite from 'expo-sqlite';
-import { Transaction, TransactionWithSplit, PlaidTransaction, SplitDecision, TransactionStatus, HistoryItem } from '@/lib/types';
+import { Transaction, PlaidTransaction, SplitDecision, TransactionStatus, HistoryItem } from '@/lib/types';
 
 let _db: SQLite.SQLiteDatabase | null = null;
 
@@ -44,9 +44,12 @@ export async function initDb(): Promise<void> {
   if (version >= 1 && version < 3) {
     await _db.execAsync(`ALTER TABLE split_decisions ADD COLUMN description TEXT;`);
   }
-  // NOTE: keep this stamp in sync with the highest migration version above.
-  // When adding a new `version < N` block, bump this to N.
-  await _db.execAsync(`PRAGMA user_version = 3;`);
+  // Only stamp when a migration actually ran, to avoid a file-header write on
+  // every cold start. Keep the literal in sync with the highest block above:
+  // when adding a `version < N` block, bump this to N.
+  if (version < 3) {
+    await _db.execAsync(`PRAGMA user_version = 3;`);
+  }
 }
 
 export async function getNewTransactions(): Promise<Transaction[]> {
@@ -100,6 +103,7 @@ export async function getHistoryTransactions(): Promise<HistoryItem[]> {
           id: r.id,
           merchant_name: title,
           amount: r.amount,
+          currency: r.currency,
           date: r.date,
           status: 'split',
           split: {
@@ -116,8 +120,14 @@ export async function getHistoryTransactions(): Promise<HistoryItem[]> {
         id: r.id,
         merchant_name: title,
         amount: r.amount,
+        currency: r.currency,
         date: r.date,
         status: r.status,
+        // A split row missing its expense id is malformed, but still surface its
+        // friends so it doesn't masquerade as a skipped row in the UI.
+        ...(r.status === 'split' && r.friend_names
+          ? { split: { friend_names: JSON.parse(r.friend_names), amount_each: r.amount_each ?? 0 } }
+          : {}),
       });
     }
   }

--- a/mobile/lib/types.ts
+++ b/mobile/lib/types.ts
@@ -21,6 +21,7 @@ export interface SplitDecision {
   friend_names: string[];        // same order as friend_ids; for offline display
   amount_each: number;
   created_at: string;
+  description?: string;          // custom title; falls back to merchant_name for display
 }
 
 export interface TransactionWithSplit extends Transaction {
@@ -57,4 +58,16 @@ export interface SplitwiseAuthResponse {
   user_id: string;
   display_name: string;
   avatar_url: string | null;
+}
+
+// A row in the History list. A combined split (multiple transactions sharing one
+// Splitwise expense) collapses into a single item with `combined` populated.
+export interface HistoryItem {
+  id: string;                 // transaction id for single rows; expense id for combined rows
+  merchant_name: string;      // display title (description ?? merchant_name)
+  amount: number;             // total (summed across members for combined rows)
+  date: string;
+  status: TransactionStatus;
+  split?: { friend_names: string[]; amount_each: number };
+  combined?: { expense_id: string; transaction_ids: string[]; count: number };
 }

--- a/mobile/lib/types.ts
+++ b/mobile/lib/types.ts
@@ -66,6 +66,7 @@ export interface HistoryItem {
   id: string;                 // transaction id for single rows; expense id for combined rows
   merchant_name: string;      // display title (description ?? merchant_name)
   amount: number;             // total (summed across members for combined rows)
+  currency: string;           // from the (first) member transaction
   date: string;
   status: TransactionStatus;
   split?: { friend_names: string[]; amount_each: number };

--- a/mobile/stores/transactionStore.ts
+++ b/mobile/stores/transactionStore.ts
@@ -87,11 +87,14 @@ export const useTransactionStore = create<TransactionState>((set, get) => ({
 
   deleteCombinedSplit: async (transactionIds, splitwiseExpenseId) => {
     // Delete the shared Splitwise expense once, then revert every member locally.
+    // Members are independent, so run their reversions concurrently.
     await deleteExpense(splitwiseExpenseId);
-    for (const id of transactionIds) {
-      await deleteSplitDecision(id);
-      await updateTransactionStatus(id, 'new');
-    }
+    await Promise.all(
+      transactionIds.map(async (id) => {
+        await deleteSplitDecision(id);
+        await updateTransactionStatus(id, 'new');
+      })
+    );
     await get().load();
   },
 }));

--- a/mobile/stores/transactionStore.ts
+++ b/mobile/stores/transactionStore.ts
@@ -20,6 +20,7 @@ interface TransactionState {
   skip: (id: string) => Promise<void>;
   markSplit: (id: string) => Promise<void>;
   deleteSplit: (transactionId: string, splitwiseExpenseId: string) => Promise<void>;
+  deleteCombinedSplit: (transactionIds: string[], splitwiseExpenseId: string) => Promise<void>;
 }
 
 export const useTransactionStore = create<TransactionState>((set, get) => ({
@@ -81,6 +82,16 @@ export const useTransactionStore = create<TransactionState>((set, get) => ({
     await deleteExpense(splitwiseExpenseId);
     await deleteSplitDecision(transactionId);
     await updateTransactionStatus(transactionId, 'new');
+    await get().load();
+  },
+
+  deleteCombinedSplit: async (transactionIds, splitwiseExpenseId) => {
+    // Delete the shared Splitwise expense once, then revert every member locally.
+    await deleteExpense(splitwiseExpenseId);
+    for (const id of transactionIds) {
+      await deleteSplitDecision(id);
+      await updateTransactionStatus(id, 'new');
+    }
     await get().load();
   },
 }));


### PR DESCRIPTION
## Summary
Adds two features to the mobile app:

- **Editable split titles** — the split sheet now has an editable title field (prefilled with the merchant name / stored title), available on both create and edit. Titles persist locally via a new `description` column on `split_decisions` (DB migration to `user_version = 3`) and are shown in History (`description ?? merchant_name`).
- **Combined transaction splits** — long-press a transaction to enter multi-select, pick several, and "Split together" to create a single Splitwise expense for the summed amount. Combined splits are modeled as N `split_decisions` rows sharing one `splitwise_expense_id`, collapse into a single grouped row in History, and can be edited or deleted as a group.

## Implementation notes
- Built TDD, one concern per commit (db migration → helpers → grouped history query → store action → picker → row select mode → transactions tab → history). 88 tests pass, `tsc --noEmit` clean.
- The `FriendPickerSheet` now drives four flows from props: single-create, edit, combine-create, combine-edit.
- **Known v1 limitation:** combine-create is not transactional — a rare DB write failure after the Splitwise expense is created could leave a partial state (same risk profile as the existing single-create path). Candidate follow-up: make the create idempotent or defer local writes until all succeed.
- **Base note:** this branch is stacked on the unmerged perf commit `60b8c24` (from `fix/friend-picker-list-perf`), which therefore appears in this PR's history until that work lands in `main`.

## Test plan
- [ ] `cd mobile && npx jest` — all suites green
- [ ] `cd mobile && npx tsc --noEmit` — no type errors
- [ ] Manual: set/edit a title on create and from History; confirm it shows in History
- [ ] Manual: clear the title → CTA disabled
- [ ] Manual: long-press → multi-select → Split together; members leave the list; History shows one grouped row with "N transactions"
- [ ] Manual: edit a combined split (friends/title); delete a combined split → all members return to Transactions and the Splitwise expense is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)