### PR TITLE
fix(web): upgrade @gorhom/bottom-sheet to v5 so split sheets open on PWA

### DIFF
--- a/mobile/components/FriendPickerSheet.tsx
+++ b/mobile/components/FriendPickerSheet.tsx
@@ -287,6 +287,7 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       <BottomSheetModal
         ref={ref}
         snapPoints={['55%', '90%']}
+        enableDynamicSizing={false}
         enablePanDownToClose
         handleIndicatorStyle={styles.indicator}
         backgroundStyle={styles.sheetBg}

--- a/mobile/components/HistoryActionSheet.tsx
+++ b/mobile/components/HistoryActionSheet.tsx
@@ -23,6 +23,7 @@ export const HistoryActionSheet = forwardRef<BottomSheetModal, Props>(
       <BottomSheetModal
         ref={ref}
         snapPoints={['38%']}
+        enableDynamicSizing={false}
         enablePanDownToClose
         handleIndicatorStyle={styles.indicator}
         backgroundStyle={styles.sheetBg}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@expo/metro-runtime": "~4.0.1",
         "@expo/vector-icons": "~14.0.4",
-        "@gorhom/bottom-sheet": "^4.6.0",
+        "@gorhom/bottom-sheet": "^5.2.14",
         "@react-native-async-storage/async-storage": "1.23.1",
         "@react-native-community/netinfo": "11.4.1",
         "expo": "~52.0.0",
@@ -2958,9 +2958,9 @@
       }
     },
     "node_modules/@gorhom/bottom-sheet": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-4.6.4.tgz",
-      "integrity": "sha512-0itLMblLBvepE065w3a60S030c2rNUsGshPC7wbWDm31VyqoaU2xjzh/ojH62YIJOcobBr5QoC30IxBBKDGovQ==",
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.14.tgz",
+      "integrity": "sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg==",
       "license": "MIT",
       "dependencies": {
         "@gorhom/portal": "1.0.14",
@@ -2971,8 +2971,8 @@
         "@types/react-native": "*",
         "react": "*",
         "react-native": "*",
-        "react-native-gesture-handler": ">=1.10.1",
-        "react-native-reanimated": ">=2.2.0"
+        "react-native-gesture-handler": ">=2.16.1",
+        "react-native-reanimated": ">=3.16.0 || >=4.0.0-"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@expo/metro-runtime": "~4.0.1",
     "@expo/vector-icons": "~14.0.4",
-    "@gorhom/bottom-sheet": "^4.6.0",
+    "@gorhom/bottom-sheet": "^5.2.14",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/netinfo": "11.4.1",
     "expo": "~52.0.0",


### PR DESCRIPTION
## Problem
On the deployed PWA, tapping **Split** on a transaction showed a blank white screen (native app unaffected).

## Root cause
`@gorhom/bottom-sheet` v4 has no web support. On web, `present()` mounts the `BottomSheetModal` at its **closed** position (`translateY == container height`, fully below the viewport) and the open animation never runs — verified in Chrome: the sheet stays frozen off-screen with no error thrown. On the installed PWA the mispositioned white sheet surface is what reads as a blank white screen.

## Fix
- Upgrade `@gorhom/bottom-sheet` `^4.6.0` → `^5.2.14` — v5 is the first release with official web support. Peer requirements are already met (Expo 52 / RN 0.76, reanimated 3.16, gesture-handler 2.20); the library is JS-only so no native rebuild is required.
- Pin `enableDynamicSizing={false}` on `FriendPickerSheet` and `HistoryActionSheet` to keep the existing snap-point sizing (v5 flips the default to `true`).

## Verification
- Reproduced the bug in Chrome against a stub route mounting the real `FriendPickerSheet`: with v4 the sheet mounts at `translateY(1107)` in a 991px viewport and never moves; with v5 it animates open and renders title, amount, search, and friend list correctly.
- `jest`: 18 suites, 125 tests pass.
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)