### PR TITLE
fix(split): make combined split create/delete atomic

### DIFF
--- a/mobile/__tests__/components/FriendPickerSheet.test.tsx
+++ b/mobile/__tests__/components/FriendPickerSheet.test.tsx
@@ -6,6 +6,7 @@ jest.mock('@/lib/splitwise', () => ({
   ...jest.requireActual('@/lib/splitwise'),
   createExpense: jest.fn(),
   updateExpense: jest.fn(),
+  deleteExpense: jest.fn(),
   getExpense: jest.fn(),
 }));
 jest.mock('@/stores/friendStore', () => ({ useFriendStore: jest.fn() }));
@@ -25,8 +26,8 @@ import { SplitDecision, Transaction } from '@/lib/types';
 const mockGetExpense = splitwise.getExpense as jest.Mock;
 const mockUpdateExpense = splitwise.updateExpense as jest.Mock;
 const mockUpsert = db.upsertSplitDecision as jest.Mock;
-const mockInsert = db.insertSplitDecision as jest.Mock;
 const mockCreateExpense = splitwise.createExpense as jest.Mock;
+const mockCommitCombined = jest.fn();
 
 const tx: Transaction = {
   id: 'tx1',
@@ -68,13 +69,15 @@ beforeEach(() => {
     isLoading: false,
   });
   (useAuthStore as jest.Mock).mockImplementation((sel) => sel({ user_id: '1' }));
-  (useTransactionStore as jest.Mock).mockImplementation((sel) => sel({ markSplit: jest.fn() }));
+  mockCommitCombined.mockReset().mockResolvedValue(undefined);
+  (useTransactionStore as jest.Mock).mockImplementation((sel) =>
+    sel({ markSplit: jest.fn(), commitCombinedSplit: mockCommitCombined })
+  );
   mockGetExpense.mockResolvedValue({ '1': 10, '2': 10 });
   mockUpdateExpense.mockResolvedValue({ amount_each: 10 });
   mockUpsert.mockResolvedValue(undefined);
   mockCreateExpense.mockResolvedValue({ expense_id: 'expNew', amount_each: 10 });
   (db.getSplitDecision as jest.Mock).mockResolvedValue(null);
-  mockInsert.mockResolvedValue(undefined);
 });
 
 test('edit mode pre-fills from the existing Splitwise expense', async () => {
@@ -141,9 +144,7 @@ test('edit mode pre-fills the title from the decision description', async () => 
   await waitFor(() => expect(screen.getByDisplayValue('Weekend trip')).toBeTruthy());
 });
 
-test('combine create sums amounts, writes one row per member, and marks each split', async () => {
-  const markSplit = jest.fn();
-  (useTransactionStore as jest.Mock).mockImplementation((sel) => sel({ markSplit }));
+test('combine create sums amounts and commits one decision row per member atomically', async () => {
   const members: Transaction[] = [
     { ...tx, id: 'txA', merchant_name: 'Starbucks', amount: 5 },
     { ...tx, id: 'txB', merchant_name: 'Uber', amount: 15 },
@@ -165,16 +166,33 @@ test('combine create sums amounts, writes one row per member, and marks each spl
   expect(mockCreateExpense).toHaveBeenCalledWith(
     expect.objectContaining({ amount: 20, description: 'Starbucks, Uber' })
   );
-  await waitFor(() => expect(mockInsert).toHaveBeenCalledTimes(2));
-  expect(mockInsert).toHaveBeenCalledWith(
-    expect.objectContaining({ transaction_id: 'txA', splitwise_expense_id: 'expNew', description: 'Starbucks, Uber' })
+  await waitFor(() => expect(mockCommitCombined).toHaveBeenCalledTimes(1));
+  const decisions = mockCommitCombined.mock.calls[0][0];
+  expect(decisions).toHaveLength(2);
+  expect(decisions).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ transaction_id: 'txA', splitwise_expense_id: 'expNew', description: 'Starbucks, Uber' }),
+      expect.objectContaining({ transaction_id: 'txB', splitwise_expense_id: 'expNew', description: 'Starbucks, Uber' }),
+    ])
   );
-  expect(mockInsert).toHaveBeenCalledWith(
-    expect.objectContaining({ transaction_id: 'txB', splitwise_expense_id: 'expNew' })
-  );
-  expect(markSplit).toHaveBeenCalledWith('txA');
-  expect(markSplit).toHaveBeenCalledWith('txB');
   expect(onSuccess).toHaveBeenCalledWith(10);
+});
+
+test('combine create rolls back the remote expense when the local commit fails', async () => {
+  mockCommitCombined.mockRejectedValue(new Error('DB_FAIL'));
+  const members: Transaction[] = [
+    { ...tx, id: 'txA', merchant_name: 'Starbucks', amount: 5 },
+    { ...tx, id: 'txB', merchant_name: 'Uber', amount: 15 },
+  ];
+  render(
+    <FriendPickerSheet transaction={null} combineTransactions={members} openToken={1} onSuccess={jest.fn()} />
+  );
+
+  fireEvent.press(screen.getByLabelText('Sam'));
+  fireEvent.press(screen.getByLabelText('Add split to Splitwise'));
+
+  await waitFor(() => expect(mockCreateExpense).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(splitwise.deleteExpense as jest.Mock).toHaveBeenCalledWith('expNew'));
 });
 
 test('combine edit upserts one row per member, reusing the decision id for its own row', async () => {
@@ -221,7 +239,8 @@ test('single create passes the edited title as the description', async () => {
   expect(mockCreateExpense).toHaveBeenCalledWith(
     expect.objectContaining({ description: 'Groceries' })
   );
-  await waitFor(() =>
-    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ description: 'Groceries', transaction_id: 'tx1' }))
-  );
+  await waitFor(() => expect(mockCommitCombined).toHaveBeenCalledTimes(1));
+  expect(mockCommitCombined.mock.calls[0][0]).toEqual([
+    expect.objectContaining({ transaction_id: 'tx1', description: 'Groceries' }),
+  ]);
 });

--- a/mobile/__tests__/lib/db.test.ts
+++ b/mobile/__tests__/lib/db.test.ts
@@ -16,6 +16,8 @@ import {
   pruneOldTransactions,
   deleteAllTransactions,
   getTransactionsByIds,
+  persistCombinedSplit,
+  revertCombinedSplit,
 } from '@/lib/db';
 import { PlaidTransaction, SplitDecision } from '@/lib/types';
 
@@ -24,6 +26,8 @@ const mockDb = {
   getAllAsync: jest.fn().mockResolvedValue([]),
   getFirstAsync: jest.fn().mockResolvedValue(null),
   runAsync: jest.fn().mockResolvedValue({ lastInsertRowId: 1, changes: 1 }),
+  // Run the transaction body immediately so inner runAsync calls are observable.
+  withTransactionAsync: jest.fn(async (task: () => Promise<void>) => { await task(); }),
 };
 
 beforeEach(() => {
@@ -319,4 +323,44 @@ test('getHistoryTransactions keeps skipped rows individual', async () => {
   expect(items[0].id).toBe('tx9');
   expect(items[0].status).toBe('skipped');
   expect(items[0].split).toBeUndefined();
+});
+
+test('persistCombinedSplit writes every row and status inside one transaction', async () => {
+  await initDb();
+  const decisions: SplitDecision[] = [
+    { id: 'a', transaction_id: 'txA', splitwise_expense_id: 'exp', friend_ids: ['2'], friend_names: ['Sam'], amount_each: 5, created_at: 'x', description: 'Trip' },
+    { id: 'b', transaction_id: 'txB', splitwise_expense_id: 'exp', friend_ids: ['2'], friend_names: ['Sam'], amount_each: 5, created_at: 'x', description: 'Trip' },
+  ];
+  await persistCombinedSplit(decisions);
+  expect(mockDb.withTransactionAsync).toHaveBeenCalledTimes(1);
+  expect(mockDb.runAsync).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO split_decisions'),
+    expect.arrayContaining(['a', 'txA', 'exp'])
+  );
+  expect(mockDb.runAsync).toHaveBeenCalledWith(
+    expect.stringContaining('UPDATE transactions SET status'),
+    ['split', 'txA']
+  );
+  expect(mockDb.runAsync).toHaveBeenCalledWith(
+    expect.stringContaining('UPDATE transactions SET status'),
+    ['split', 'txB']
+  );
+});
+
+test('revertCombinedSplit deletes rows and reverts statuses inside one transaction', async () => {
+  await initDb();
+  await revertCombinedSplit(['txA', 'txB']);
+  expect(mockDb.withTransactionAsync).toHaveBeenCalledTimes(1);
+  expect(mockDb.runAsync).toHaveBeenCalledWith(
+    expect.stringContaining('DELETE FROM split_decisions'),
+    ['txA']
+  );
+  expect(mockDb.runAsync).toHaveBeenCalledWith(
+    expect.stringContaining('UPDATE transactions SET status'),
+    ['new', 'txA']
+  );
+  expect(mockDb.runAsync).toHaveBeenCalledWith(
+    expect.stringContaining('UPDATE transactions SET status'),
+    ['new', 'txB']
+  );
 });

--- a/mobile/__tests__/stores/transactionStore.test.ts
+++ b/mobile/__tests__/stores/transactionStore.test.ts
@@ -35,6 +35,8 @@ const mockGetTokensAndCursors = jest.fn();
 const mockSaveCursor = jest.fn();
 const mockDeleteExpense = splitwise.deleteExpense as jest.Mock;
 const mockDeleteSplitDecision = db.deleteSplitDecision as jest.Mock;
+const mockPersistCombined = db.persistCombinedSplit as jest.Mock;
+const mockRevertCombined = db.revertCombinedSplit as jest.Mock;
 
 function syncPage(overrides: Partial<{
   added: unknown[];
@@ -65,6 +67,8 @@ beforeEach(() => {
   mockSaveCursor.mockResolvedValue(undefined);
   mockDeleteExpense.mockResolvedValue(undefined);
   mockDeleteSplitDecision.mockResolvedValue(undefined);
+  mockPersistCombined.mockResolvedValue(undefined);
+  mockRevertCombined.mockResolvedValue(undefined);
 });
 
 test('load fetches new transactions from DB and updates store', async () => {
@@ -173,13 +177,36 @@ test('deleteSplit leaves local state untouched if the Splitwise delete fails', a
   expect(mockUpdateStatus).not.toHaveBeenCalled();
 });
 
-test('deleteCombinedSplit deletes the expense once and reverts all members', async () => {
+test('deleteCombinedSplit deletes the expense once, then reverts members atomically', async () => {
   await useTransactionStore.getState().deleteCombinedSplit(['tx1', 'tx2'], 'expShared');
 
   expect(mockDeleteExpense).toHaveBeenCalledTimes(1);
   expect(mockDeleteExpense).toHaveBeenCalledWith('expShared');
-  expect(mockDeleteSplitDecision).toHaveBeenCalledWith('tx1');
-  expect(mockDeleteSplitDecision).toHaveBeenCalledWith('tx2');
-  expect(mockUpdateStatus).toHaveBeenCalledWith('tx1', 'new');
-  expect(mockUpdateStatus).toHaveBeenCalledWith('tx2', 'new');
+  expect(mockRevertCombined).toHaveBeenCalledWith(['tx1', 'tx2']);
+});
+
+test('deleteCombinedSplit makes no local change when the Splitwise delete fails', async () => {
+  mockDeleteExpense.mockRejectedValue(new Error('SPLITWISE_ERROR'));
+  await expect(
+    useTransactionStore.getState().deleteCombinedSplit(['tx1', 'tx2'], 'expShared')
+  ).rejects.toThrow();
+  expect(mockRevertCombined).not.toHaveBeenCalled();
+});
+
+test('commitCombinedSplit persists rows atomically then drops members from the list', async () => {
+  useTransactionStore.setState({
+    transactions: [
+      { id: 'txA', merchant_name: 'A', amount: 5, currency: 'USD', date: 'x', status: 'new', pending: false, created_at: 'x' },
+      { id: 'txB', merchant_name: 'B', amount: 5, currency: 'USD', date: 'x', status: 'new', pending: false, created_at: 'x' },
+      { id: 'txC', merchant_name: 'C', amount: 5, currency: 'USD', date: 'x', status: 'new', pending: false, created_at: 'x' },
+    ],
+    isLoading: false,
+  });
+  const decisions = [
+    { id: 'a', transaction_id: 'txA', splitwise_expense_id: 'exp', friend_ids: ['2'], friend_names: ['Sam'], amount_each: 5, created_at: 'x', description: 'Trip' },
+    { id: 'b', transaction_id: 'txB', splitwise_expense_id: 'exp', friend_ids: ['2'], friend_names: ['Sam'], amount_each: 5, created_at: 'x', description: 'Trip' },
+  ];
+  await useTransactionStore.getState().commitCombinedSplit(decisions);
+  expect(mockPersistCombined).toHaveBeenCalledWith(decisions);
+  expect(useTransactionStore.getState().transactions.map((t) => t.id)).toEqual(['txC']);
 });

--- a/mobile/components/FriendPickerSheet.tsx
+++ b/mobile/components/FriendPickerSheet.tsx
@@ -17,8 +17,8 @@ import { Ionicons } from '@expo/vector-icons';
 import { useFriendStore } from '@/stores/friendStore';
 import { useAuthStore } from '@/stores/authStore';
 import { useTransactionStore } from '@/stores/transactionStore';
-import { getSplitDecision, insertSplitDecision, upsertSplitDecision, updateTransactionStatus } from '@/lib/db';
-import { createExpense, updateExpense, getExpense, SplitwiseAuthError } from '@/lib/splitwise';
+import { getSplitDecision, upsertSplitDecision } from '@/lib/db';
+import { createExpense, updateExpense, deleteExpense, getExpense, SplitwiseAuthError } from '@/lib/splitwise';
 import { SplitwiseFriend, Transaction, SplitDecision } from '@/lib/types';
 import { useToast } from '@/components/ToastProvider';
 import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
@@ -49,6 +49,7 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
     const { friends, isLoading } = useFriendStore();
     const user_id = useAuthStore((s) => s.user_id);
     const markSplit = useTransactionStore((s) => s.markSplit);
+    const commitCombinedSplit = useTransactionStore((s) => s.commitCombinedSplit);
 
     const members = useMemo(
       () =>
@@ -183,17 +184,6 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       setCustomAmounts((prev) => ({ ...prev, [id]: value }));
     }
 
-    async function insertWithRetry(decision: SplitDecision) {
-      for (let attempt = 1; attempt <= 3; attempt++) {
-        try {
-          await insertSplitDecision(decision);
-          return;
-        } catch {
-          if (attempt === 3) throw new Error('DB_WRITE_FAILED');
-        }
-      }
-    }
-
     async function handleAddToSplitwise() {
       if (ctaDisabled) return;
       setSubmitting(true);
@@ -233,7 +223,6 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
         if (!isCombine) {
           const existing = await getSplitDecision(members[0].id);
           if (existing) {
-            await updateTransactionStatus(members[0].id, 'split');
             await markSplit(members[0].id);
             onSuccess(existing.amount_each);
             return;
@@ -249,24 +238,30 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
           ...shares,
         });
 
-        // Persist every member row before flipping any status, so a mid-loop DB
-        // failure never leaves the list half-marked (some members removed, some not).
         const ts = Date.now();
         const createdAt = new Date().toISOString();
-        for (const t of members) {
-          await insertWithRetry({
-            id: `${t.id}-${ts}`,
-            transaction_id: t.id,
-            splitwise_expense_id: expense_id,
-            friend_ids: friendIds,
-            friend_names: friendNames,
-            amount_each,
-            created_at: createdAt,
-            description: desc,
-          });
-        }
-        for (const t of members) {
-          await markSplit(t.id);
+        const decisions: SplitDecision[] = members.map((t) => ({
+          id: `${t.id}-${ts}`,
+          transaction_id: t.id,
+          splitwise_expense_id: expense_id,
+          friend_ids: friendIds,
+          friend_names: friendNames,
+          amount_each,
+          created_at: createdAt,
+          description: desc,
+        }));
+        try {
+          // Persist all member rows + statuses atomically.
+          await commitCombinedSplit(decisions);
+        } catch (dbErr) {
+          // Local commit failed after the remote expense was created — undo the
+          // remote side so no orphan is left and a retry won't create a duplicate.
+          try {
+            await deleteExpense(expense_id);
+          } catch {
+            // Best-effort rollback; surface the original failure below.
+          }
+          throw dbErr;
         }
         onSuccess(amount_each);
       } catch (err) {

--- a/mobile/lib/db.ts
+++ b/mobile/lib/db.ts
@@ -255,6 +255,29 @@ export async function deleteSplitDecision(transactionId: string): Promise<void> 
   );
 }
 
+// Atomically persist every member's decision row and flip its transaction to
+// 'split'. Wrapped in a single SQLite transaction so a mid-batch failure rolls
+// back the whole combined split locally (no half-written members).
+export async function persistCombinedSplit(decisions: SplitDecision[]): Promise<void> {
+  await db().withTransactionAsync(async () => {
+    for (const d of decisions) {
+      await insertSplitDecision(d);
+      await updateTransactionStatus(d.transaction_id, 'split');
+    }
+  });
+}
+
+// Atomically delete every member's decision row and revert its transaction to
+// 'new'. Single transaction so a failure can't leave the group half-reverted.
+export async function revertCombinedSplit(transactionIds: string[]): Promise<void> {
+  await db().withTransactionAsync(async () => {
+    for (const id of transactionIds) {
+      await deleteSplitDecision(id);
+      await updateTransactionStatus(id, 'new');
+    }
+  });
+}
+
 export async function pruneOldTransactions(): Promise<void> {
   await db().runAsync(
     `DELETE FROM transactions WHERE created_at < datetime('now', '-6 months')`,

--- a/mobile/stores/transactionStore.ts
+++ b/mobile/stores/transactionStore.ts
@@ -8,8 +8,10 @@ import {
   deleteTransactionsByPlaidIds,
   updateTransactionStatus,
   deleteSplitDecision,
+  persistCombinedSplit,
+  revertCombinedSplit,
 } from '@/lib/db';
-import { Transaction } from '@/lib/types';
+import { Transaction, SplitDecision } from '@/lib/types';
 import { usePlaidStore } from '@/stores/plaidStore';
 
 interface TransactionState {
@@ -19,6 +21,7 @@ interface TransactionState {
   refresh: () => Promise<void>;
   skip: (id: string) => Promise<void>;
   markSplit: (id: string) => Promise<void>;
+  commitCombinedSplit: (decisions: SplitDecision[]) => Promise<void>;
   deleteSplit: (transactionId: string, splitwiseExpenseId: string) => Promise<void>;
   deleteCombinedSplit: (transactionIds: string[], splitwiseExpenseId: string) => Promise<void>;
 }
@@ -77,6 +80,13 @@ export const useTransactionStore = create<TransactionState>((set, get) => ({
     set((s) => ({ transactions: s.transactions.filter((t) => t.id !== id) }));
   },
 
+  commitCombinedSplit: async (decisions) => {
+    // Persist all member rows + statuses atomically, then drop them from the list.
+    await persistCombinedSplit(decisions);
+    const ids = new Set(decisions.map((d) => d.transaction_id));
+    set((s) => ({ transactions: s.transactions.filter((t) => !ids.has(t.id)) }));
+  },
+
   deleteSplit: async (transactionId, splitwiseExpenseId) => {
     // Splitwise first: if it fails we make no local change, so the two stay in sync.
     await deleteExpense(splitwiseExpenseId);
@@ -86,15 +96,10 @@ export const useTransactionStore = create<TransactionState>((set, get) => ({
   },
 
   deleteCombinedSplit: async (transactionIds, splitwiseExpenseId) => {
-    // Delete the shared Splitwise expense once, then revert every member locally.
-    // Members are independent, so run their reversions concurrently.
+    // Delete the shared Splitwise expense once, then revert every member locally
+    // in a single transaction so a failure can't leave the group half-reverted.
     await deleteExpense(splitwiseExpenseId);
-    await Promise.all(
-      transactionIds.map(async (id) => {
-        await deleteSplitDecision(id);
-        await updateTransactionStatus(id, 'new');
-      })
-    );
+    await revertCombinedSplit(transactionIds);
     await get().load();
   },
 }));


### PR DESCRIPTION
## Problem

Combined splits write multiple rows locally. If a failure happened mid-batch, the group could be left **half-written** (on create) or **half-reverted** (on delete). On create, a local commit failing *after* the Splitwise expense was already created left an **orphan remote expense**, and a retry would **duplicate** it.

## Fix

- Wrap the multi-row local writes in a single SQLite transaction — `persistCombinedSplit` / `revertCombinedSplit` — so a mid-batch failure can't leave the group partially written or partially reverted.
- On combine create, if the local commit fails after the Splitwise expense was created, **roll back the remote expense** so no orphan is left and a retry won't duplicate it.

## Changes
- `mobile/lib/db.ts` — atomic `persistCombinedSplit` / `revertCombinedSplit` helpers
- `mobile/stores/transactionStore.ts` — remote-expense rollback on local-commit failure
- `mobile/components/FriendPickerSheet.tsx` — wire-up
- Tests: `db.test.ts`, `transactionStore.test.ts`, `FriendPickerSheet.test.tsx`

## Notes
- Branch was based on an earlier main; the PR diff (merge-base three-dot) is clean — only the 6 files above. Trial merge into current `main` shows no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)