### PR TITLE
fix(pwa): blank white screen when tapping Split on a transaction

### DIFF
--- a/mobile/__tests__/components/FriendPickerSheet.test.tsx
+++ b/mobile/__tests__/components/FriendPickerSheet.test.tsx
@@ -225,3 +225,26 @@ test('single create passes the edited title as the description', async () => {
     expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ description: 'Groceries', transaction_id: 'tx1' }))
   );
 });
+
+// Regression: the sheet renders null until it has a transaction, so every hook
+// must run before that bail-out. When it didn't, the render that first supplied
+// a transaction — i.e. tapping Split — added a hook the previous render lacked
+// and React tore the whole tree down (blank white screen on the PWA).
+test('going from no transaction to a transaction does not change the hook count', () => {
+  const { rerender } = render(
+    <FriendPickerSheet transaction={null} openToken={0} onSuccess={jest.fn()} />
+  );
+  expect(screen.queryByLabelText('Split title')).toBeNull();
+
+  expect(() =>
+    rerender(
+      <FriendPickerSheet
+        transaction={{ ...tx, status: 'new' }}
+        openToken={1}
+        onSuccess={jest.fn()}
+      />
+    )
+  ).not.toThrow();
+
+  expect(screen.getByLabelText('Split title').props.value).toBe('Amazon');
+});

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -28,6 +28,7 @@ export default function NewTransactionsScreen() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [combineTxs, setCombineTxs] = useState<Transaction[] | null>(null);
   const [pickerToken, setPickerToken] = useState(0);
+  const [pendingPresent, setPendingPresent] = useState(false);
 
   useEffect(() => {
     load();
@@ -36,11 +37,21 @@ export default function NewTransactionsScreen() {
     return unsub;
   }, []);
 
+  // Present from an effect, after the sheet has rendered with the chosen
+  // transaction — same reason as the history screen. FriendPickerSheet renders
+  // null while it has no transaction, so on the first tap sheetRef.current is
+  // still null and a synchronous present() silently does nothing.
+  useEffect(() => {
+    if (!pendingPresent) return;
+    sheetRef.current?.present();
+    setPendingPresent(false);
+  }, [pendingPresent]);
+
   function openSheet(tx: Transaction) {
     setCombineTxs(null);
     setSelected(tx);
     setPickerToken((t) => t + 1);
-    sheetRef.current?.present();
+    setPendingPresent(true);
   }
 
   function enterSelect(tx: Transaction) {
@@ -72,7 +83,7 @@ export default function NewTransactionsScreen() {
     setSelected(null);
     setCombineTxs(members);
     setPickerToken((t) => t + 1);
-    sheetRef.current?.present();
+    setPendingPresent(true);
   }
 
   function handleSplitSuccess(amountEach: number) {

--- a/mobile/components/FriendPickerSheet.tsx
+++ b/mobile/components/FriendPickerSheet.tsx
@@ -134,6 +134,19 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       [friends, selected]
     );
 
+    // Stable so memoized EqualRows only re-render when their own selection flips.
+    const toggle = useCallback((id: string) => {
+      setSelected((prev) => {
+        const next = new Set(prev);
+        next.has(id) ? next.delete(id) : next.add(id);
+        return next;
+      });
+    }, []);
+
+    // Every hook must run before this bail-out, or the render that first
+    // supplies a transaction adds hooks the previous render didn't have and
+    // React throws "rendered more hooks than during the previous render" —
+    // which unmounts the whole tree (blank screen) on tapping Split.
     if (members.length === 0) return null;
 
     const totalCents = Math.round(totalAmount * 100);
@@ -151,15 +164,6 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
     const ownerShareCents = totalCents - friendTotalCents;
     const isOverBudget = ownerShareCents < -1;
     const ctaDisabled = selected.size === 0 || submitting || isOverBudget || title.trim() === '';
-
-    // Stable so memoized EqualRows only re-render when their own selection flips.
-    const toggle = useCallback((id: string) => {
-      setSelected((prev) => {
-        const next = new Set(prev);
-        next.has(id) ? next.delete(id) : next.add(id);
-        return next;
-      });
-    }, []);
 
     function switchToCustom() {
       const baseShareCents = Math.floor(totalCents / n);


### PR DESCRIPTION
## Problem

Tapping **Split** on any transaction in the PWA showed a blank white screen.

## Root cause

`FriendPickerSheet` had a `useCallback` **after** its `if (members.length === 0) return null;` bail-out. The sheet renders `null` until it is given a transaction, so:

- before tapping Split, `transaction` is `null` → early return → 10 hooks run;
- on tapping Split, `transaction` is set → render continues past the bail-out → an 11th hook runs.

React throws `Rendered more hooks than during the previous render.` — a red box in dev, and a torn-down component tree (blank white screen) in the production PWA build.

A second defect sat behind it: `openSheet` in `app/(tabs)/index.tsx` called `sheetRef.current?.present()` synchronously in the tap handler, but the sheet still rendered `null` at that moment, so the ref was `null` and `present()` silently did nothing. `history.tsx` already had a comment about this exact trap and worked around it; the transactions tab did not.

## Changes

- `components/FriendPickerSheet.tsx` — move the `toggle` `useCallback` above the bail-out, with a comment on the invariant.
- `app/(tabs)/index.tsx` — present the sheet from an effect once it has rendered with the chosen transaction, matching the history screen. Covers both single-split and "split together".
- `__tests__/components/FriendPickerSheet.test.tsx` — regression test that renders with `transaction={null}` then re-renders with a transaction.

## Verification

Ran the web build locally and drove it in Chrome with a seeded session and transactions.

- **Before:** tapping Split → uncaught `Rendered more hooks than during the previous render.` at `FriendPickerSheet.tsx:156`.
- **After:** tapping Split opens the picker on the first tap, fully rendered (merchant, amount, title field, friend search, CTA). Same for the History tab's "tap to split" path. No hook errors in the console.

The new test was confirmed to fail against the old hook placement and pass with the fix. 126 tests pass; `tsc --noEmit` is clean.

## Out of scope

With a desktop **mouse**, presses inside the swipeable transaction rows are intercepted by `react-native-gesture-handler` and never fire — touch is unaffected, which is why this bug was reachable on a phone. Noted for a separate look; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyJ9WsYgjMFpZNRm6rZoGK
