### PR TITLE
fix(web): implement combined-split writes missing from db.web

### DIFF
--- a/mobile/__tests__/lib/db.parity.test.ts
+++ b/mobile/__tests__/lib/db.parity.test.ts
@@ -1,0 +1,16 @@
+// mobile/__tests__/lib/db.parity.test.ts
+// Metro resolves `@/lib/db` to db.web.ts on web, so any function db.ts exports
+// but db.web.ts doesn't is `undefined` at runtime in the PWA — it throws only
+// when the feature is used, after side effects (e.g. a created Splitwise
+// expense) have already happened. Fail at test time instead.
+jest.mock('expo-sqlite');
+
+import * as native from '@/lib/db';
+import * as web from '@/lib/db.web';
+
+test('db.web implements every function db.ts exports', () => {
+  const missing = Object.keys(native).filter(
+    (name) => typeof (web as Record<string, unknown>)[name] !== 'function'
+  );
+  expect(missing).toEqual([]);
+});

--- a/mobile/__tests__/lib/db.web.test.ts
+++ b/mobile/__tests__/lib/db.web.test.ts
@@ -5,6 +5,7 @@ import {
   deleteTransactionsByPlaidIds, updateTransactionStatus, getSplitDecision,
   insertSplitDecision, upsertSplitDecision, deleteSplitDecision,
   pruneOldTransactions, deleteAllTransactions,
+  persistCombinedSplit, revertCombinedSplit,
 } from '@/lib/db.web';
 import { PlaidTransaction, SplitDecision } from '@/lib/types';
 
@@ -130,6 +131,37 @@ describe('db.web (IndexedDB)', () => {
     expect(await getSplitDecision('told')).toBeNull();
     expect((await getHistoryTransactions()).find((h) => h.id === 'told')).toBeUndefined();
     expect(await getNewTransactions()).toHaveLength(1);
+  });
+
+  it('persistCombinedSplit writes every decision and marks each transaction split', async () => {
+    await upsertTransactions([plaidTx('t1'), plaidTx('t2')]);
+    await persistCombinedSplit([
+      decision('t1', { splitwise_expense_id: 'exp', description: 'Trip' }),
+      decision('t2', { splitwise_expense_id: 'exp', description: 'Trip' }),
+    ]);
+    expect(await getNewTransactions()).toHaveLength(0);
+    expect(await getSplitDecision('t1')).toMatchObject({ splitwise_expense_id: 'exp' });
+    expect(await getSplitDecision('t2')).toMatchObject({ splitwise_expense_id: 'exp' });
+  });
+
+  it('persistCombinedSplit rolls the whole group back when one row is a duplicate', async () => {
+    await upsertTransactions([plaidTx('t1'), plaidTx('t2')]);
+    await insertSplitDecision(decision('t2'));
+    await expect(
+      persistCombinedSplit([decision('t1'), decision('t2')])
+    ).rejects.toBeTruthy();
+    // t1 must be untouched: no decision row, still 'new'.
+    expect(await getSplitDecision('t1')).toBeNull();
+    expect((await getNewTransactions()).map((t) => t.id)).toContain('t1');
+  });
+
+  it('revertCombinedSplit deletes decisions and returns transactions to new', async () => {
+    await upsertTransactions([plaidTx('t1'), plaidTx('t2')]);
+    await persistCombinedSplit([decision('t1'), decision('t2')]);
+    await revertCombinedSplit(['t1', 't2']);
+    expect(await getSplitDecision('t1')).toBeNull();
+    expect(await getSplitDecision('t2')).toBeNull();
+    expect((await getNewTransactions()).map((t) => t.id).sort()).toEqual(['t1', 't2']);
   });
 
   it('getTransactionsByIds returns matching rows and skips missing ids', async () => {

--- a/mobile/lib/db.web.ts
+++ b/mobile/lib/db.web.ts
@@ -219,6 +219,46 @@ export async function deleteSplitDecision(transactionId: string): Promise<void> 
   await done(tx);
 }
 
+// Atomically write every member's decision row and flip its transaction to
+// 'split'. One IDB transaction across both stores mirrors the SQLite
+// withTransactionAsync version: any failure aborts the whole group.
+export async function persistCombinedSplit(decisions: SplitDecision[]): Promise<void> {
+  if (decisions.length === 0) return;
+  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const txStore = tx.objectStore(TX_STORE);
+  // Read every row up front, then issue all writes: a write that fails aborts
+  // the txn, and a later get() on an aborting txn would reject with a less
+  // useful error than the abort reason done() surfaces.
+  const rows = await Promise.all(
+    decisions.map((d) => req(txStore.get(d.transaction_id) as IDBRequest<Transaction | undefined>)),
+  );
+  decisions.forEach((d, i) => {
+    // add() (not put) rejects a duplicate transaction_id, matching the SQLite
+    // UNIQUE(transaction_id) constraint.
+    tx.objectStore(DECISION_STORE).add(d);
+    const existing = rows[i];
+    if (existing) txStore.put({ ...existing, status: 'split' });
+  });
+  await done(tx);
+}
+
+// Atomically delete every member's decision row and revert its transaction to
+// 'new'. Single transaction so a failure can't leave the group half-reverted.
+export async function revertCombinedSplit(transactionIds: string[]): Promise<void> {
+  if (transactionIds.length === 0) return;
+  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const txStore = tx.objectStore(TX_STORE);
+  const rows = await Promise.all(
+    transactionIds.map((id) => req(txStore.get(id) as IDBRequest<Transaction | undefined>)),
+  );
+  transactionIds.forEach((id, i) => {
+    tx.objectStore(DECISION_STORE).delete(id);
+    const existing = rows[i];
+    if (existing) txStore.put({ ...existing, status: 'new' });
+  });
+  await done(tx);
+}
+
 export async function pruneOldTransactions(): Promise<void> {
   const cutoff = new Date();
   cutoff.setMonth(cutoff.getMonth() - 6);


### PR DESCRIPTION
## The bug

Adding a split in the PWA showed **"Failed to add expense. Please try again."** — but the expense appeared in Splitwise and was deleted a second later.

That delete is our own rollback. `FriendPickerSheet.handleAddToSplitwise` creates the expense, then calls `commitCombinedSplit` → `persistCombinedSplit` from `@/lib/db`. Metro resolves `@/lib/db` to `lib/db.web.ts` (IndexedDB) on web, and #58 added `persistCombinedSplit`/`revertCombinedSplit` to `lib/db.ts` only. Both imports were `undefined` in the PWA, so the call threw a TypeError, the `catch` deleted the just-created expense, and the toast fired. Every split on web, not just combined ones. Native was unaffected.

`revertCombinedSplit` was missing too, which broke deleting a split from History in a worse way: it deletes the Splitwise expense *first*, then throws — expense gone from Splitwise, still shown as split in the app.

## The fix

- `lib/db.web.ts`: both functions implemented over a single IDB `readwrite` transaction spanning `transactions` + `split_decisions`, so a failure aborts the whole group (parity with SQLite's `withTransactionAsync`). Reads are issued up front and writes after — a write that fails aborts the transaction, and a later `get()` on a dying transaction would reject with a less useful error than the abort reason `done()` surfaces.
- `__tests__/lib/db.web.test.ts`: happy path, group rollback on a duplicate `transaction_id`, and revert.
- `__tests__/lib/db.parity.test.ts` (new): asserts `db.web.ts` exports a function for every export of `db.ts`. Verified it fails with exactly `["persistCombinedSplit", "revertCombinedSplit"]` when the `db.web.ts` change is stashed.

## Verification

`npx tsc --noEmit` clean; full suite 135/135 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyJ9WsYgjMFpZNRm6rZoGK