### PR TITLE
fix: preserve split info across Plaid pending → posted transitions

### DIFF
--- a/mobile/__tests__/lib/db.test.ts
+++ b/mobile/__tests__/lib/db.test.ts
@@ -30,6 +30,10 @@ import {
   assignTransactionsToVacation,
   removeTransactionFromVacation,
   reconcileVacationStatuses,
+  rekeyTransaction,
+  markTransactionsReversed,
+  getReviewTransactions,
+  clearReview,
 } from '@/lib/db';
 import { PlaidTransaction, SplitDecision } from '@/lib/types';
 import { VacationConflictError } from '@/lib/vacationErrors';
@@ -207,7 +211,7 @@ test('initDb migrates a v1 install by adding both pending and description column
     expect.stringContaining('ALTER TABLE split_decisions ADD COLUMN description')
   );
   expect(mockDb.execAsync).toHaveBeenCalledWith(
-    expect.stringContaining('user_version = 4')
+    expect.stringContaining('user_version = 5')
   );
 });
 
@@ -218,8 +222,31 @@ test('initDb migrates an existing v2 install by adding the description column', 
     expect.stringContaining('ALTER TABLE split_decisions ADD COLUMN description')
   );
   expect(mockDb.execAsync).toHaveBeenCalledWith(
-    expect.stringContaining('user_version = 4')
+    expect.stringContaining('user_version = 5')
   );
+});
+
+test('initDb migrates an existing v4 install by adding review columns', async () => {
+  mockDb.getFirstAsync.mockResolvedValueOnce({ user_version: 4 });
+  await initDb();
+  expect(mockDb.execAsync).toHaveBeenCalledWith(
+    expect.stringContaining('ALTER TABLE transactions ADD COLUMN review_reason')
+  );
+  expect(mockDb.execAsync).toHaveBeenCalledWith(
+    expect.stringContaining('ALTER TABLE transactions ADD COLUMN amount_changed_from')
+  );
+  expect(mockDb.execAsync).toHaveBeenCalledWith(
+    expect.stringContaining('user_version = 5')
+  );
+});
+
+test('initDb skips the review-column migration when already at version 5', async () => {
+  mockDb.getFirstAsync.mockResolvedValueOnce({ user_version: 5 });
+  await initDb();
+  const alterCalls = mockDb.execAsync.mock.calls.filter(([sql]: [string]) =>
+    sql.includes('ADD COLUMN review_reason')
+  );
+  expect(alterCalls).toHaveLength(0);
 });
 
 test('insertSplitDecision persists the description', async () => {
@@ -378,9 +405,250 @@ test('revertCombinedSplit deletes rows and reverts statuses inside one transacti
   );
 });
 
+test('deleteTransactionsByPlaidIds also deletes matching split_decisions rows (inert-cascade regression)', async () => {
+  // Native SQLite never issues `PRAGMA foreign_keys = ON`, so the
+  // `ON DELETE CASCADE` on split_decisions.transaction_id is inert — this
+  // must delete split_decisions explicitly, mirroring db.web.ts.
+  await initDb();
+  await deleteTransactionsByPlaidIds(['tx1', 'tx2']);
+  expect(mockDb.runAsync).toHaveBeenCalledWith(
+    expect.stringContaining('DELETE FROM split_decisions WHERE transaction_id IN'),
+    ['tx1', 'tx2']
+  );
+  expect(mockDb.runAsync).toHaveBeenCalledWith(
+    expect.stringContaining('DELETE FROM transactions WHERE id IN'),
+    ['tx1', 'tx2']
+  );
+});
+
+describe('rekeyTransaction', () => {
+  beforeEach(async () => {
+    await initDb();
+  });
+
+  function posted(over: Partial<PlaidTransaction> = {}): PlaidTransaction {
+    return {
+      transaction_id: 'new1', merchant_name: 'Cafe', name: 'CAFE', amount: 10,
+      iso_currency_code: 'USD', date: '2026-08-01', pending: false, ...over,
+    };
+  }
+
+  test('returns not_found and writes nothing when the old id does not exist', async () => {
+    mockDb.getFirstAsync.mockResolvedValueOnce(null);
+    const result = await rekeyTransaction('old1', posted());
+    expect(result).toBe('not_found');
+    expect(mockDb.runAsync).not.toHaveBeenCalled();
+  });
+
+  test('unchanged amount: rekeys the row, clears pending, sets no review flag', async () => {
+    mockDb.getFirstAsync.mockResolvedValueOnce({ id: 'old1', amount: 10, status: 'split' });
+    const result = await rekeyTransaction('old1', posted({ amount: 10 }));
+    expect(result).toBe('unchanged');
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE transactions SET id'),
+      ['new1', 'Cafe', 10, '2026-08-01', null, null, 'old1']
+    );
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE split_decisions SET transaction_id'),
+      ['new1', 'old1']
+    );
+  });
+
+  test('changed amount on a split row: flags amount_changed with the old amount, decision follows to the new id', async () => {
+    mockDb.getFirstAsync.mockResolvedValueOnce({ id: 'old1', amount: 10, status: 'split' });
+    const result = await rekeyTransaction('old1', posted({ amount: 12.5 }));
+    expect(result).toBe('changed');
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE transactions SET id'),
+      ['new1', 'Cafe', 12.5, '2026-08-01', 'amount_changed', 10, 'old1']
+    );
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE split_decisions SET transaction_id'),
+      ['new1', 'old1']
+    );
+  });
+
+  test('changed amount on a new row: no review flag, new amount stored', async () => {
+    mockDb.getFirstAsync.mockResolvedValueOnce({ id: 'old1', amount: 10, status: 'new' });
+    const result = await rekeyTransaction('old1', posted({ amount: 12.5 }));
+    expect(result).toBe('changed');
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE transactions SET id'),
+      ['new1', 'Cafe', 12.5, '2026-08-01', null, null, 'old1']
+    );
+  });
+
+  test('changed amount on a skipped row: no review flag, new amount stored', async () => {
+    mockDb.getFirstAsync.mockResolvedValueOnce({ id: 'old1', amount: 10, status: 'skipped' });
+    const result = await rekeyTransaction('old1', posted({ amount: 12.5 }));
+    expect(result).toBe('changed');
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE transactions SET id'),
+      ['new1', 'Cafe', 12.5, '2026-08-01', null, null, 'old1']
+    );
+  });
+
+  test('conflict: a split row already occupying the posted id is never clobbered', async () => {
+    mockDb.getFirstAsync
+      .mockResolvedValueOnce({ id: 'old1', amount: 10, status: 'split' })
+      .mockResolvedValueOnce({ id: 'new1', status: 'split' });
+    const result = await rekeyTransaction('old1', posted({ amount: 12.5 }));
+    expect(result).toBe('conflict');
+    expect(mockDb.runAsync).not.toHaveBeenCalled();
+  });
+
+  test('duplicate: a non-split row occupying the posted id is dropped, then the rekey proceeds', async () => {
+    mockDb.getFirstAsync
+      .mockResolvedValueOnce({ id: 'old1', amount: 10, status: 'split' })
+      .mockResolvedValueOnce({ id: 'new1', status: 'new' });
+    const result = await rekeyTransaction('old1', posted({ amount: 12.5 }));
+    expect(result).toBe('changed');
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM transactions'),
+      ['new1']
+    );
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE transactions SET id'),
+      ['new1', 'Cafe', 12.5, '2026-08-01', 'amount_changed', 10, 'old1']
+    );
+  });
+
+  test('does not probe for a collision when the posted id is unchanged', async () => {
+    mockDb.getFirstAsync.mockClear(); // drop initDb's user_version read from the count
+    mockDb.getFirstAsync.mockResolvedValueOnce({ id: 'old1', amount: 10, status: 'split' });
+    const result = await rekeyTransaction('old1', posted({ transaction_id: 'old1', amount: 10 }));
+    expect(result).toBe('unchanged');
+    expect(mockDb.getFirstAsync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('markTransactionsReversed', () => {
+  beforeEach(async () => {
+    await initDb();
+  });
+
+  test('keeps and flags a split row as reversed', async () => {
+    mockDb.getAllAsync.mockResolvedValueOnce([
+      { id: 'tx1', merchant_name: 'Cafe', amount: 10, currency: 'USD', date: '2026-08-01', status: 'split', pending: 0, created_at: 'x' },
+    ]);
+    const kept = await markTransactionsReversed(['tx1']);
+    expect(kept).toEqual(['tx1']);
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining("review_reason = 'reversed'"),
+      ['tx1']
+    );
+  });
+
+  test('deletes a new/skipped row along with its decision', async () => {
+    mockDb.getAllAsync.mockResolvedValueOnce([
+      { id: 'tx1', merchant_name: 'Cafe', amount: 10, currency: 'USD', date: '2026-08-01', status: 'new', pending: 0, created_at: 'x' },
+    ]);
+    const kept = await markTransactionsReversed(['tx1']);
+    expect(kept).toEqual([]);
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM split_decisions'),
+      ['tx1']
+    );
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM transactions'),
+      ['tx1']
+    );
+  });
+
+  test('is a no-op for an empty list', async () => {
+    mockDb.runAsync.mockClear();
+    const kept = await markTransactionsReversed([]);
+    expect(kept).toEqual([]);
+    expect(mockDb.runAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('getReviewTransactions', () => {
+  beforeEach(async () => {
+    await initDb();
+  });
+
+  test('returns single review rows with the review reason and amounts', async () => {
+    mockDb.getAllAsync.mockResolvedValueOnce([
+      { id: 'tx1', merchant_name: 'Cafe', amount: 12.5, currency: 'USD', date: '2026-08-01', status: 'split', pending: 0, created_at: 'x',
+        review_reason: 'amount_changed', amount_changed_from: 10,
+        splitwise_expense_id: 'exp1', description: null, friend_names: '["Sam"]', amount_each: 6.25 },
+    ]);
+    const items = await getReviewTransactions();
+    expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+      expect.stringContaining('review_reason IS NOT NULL'),
+      []
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      id: 'tx1', reason: 'amount_changed', amount: 12.5, amount_changed_from: 10,
+      expense_id: 'exp1', transaction_ids: ['tx1'],
+    });
+    expect(items[0].split.friend_names).toEqual(['Sam']);
+  });
+
+  test('groups combined-split members sharing an expense id, summing both amounts', async () => {
+    mockDb.getAllAsync.mockResolvedValueOnce([
+      { id: 'tx1', merchant_name: 'Cafe', amount: 12, currency: 'USD', date: '2026-08-02', status: 'split', pending: 0, created_at: 'x',
+        review_reason: 'amount_changed', amount_changed_from: 10,
+        splitwise_expense_id: 'expShared', description: 'Trip', friend_names: '["Sam"]', amount_each: 6 },
+      { id: 'tx2', merchant_name: 'Uber', amount: 8, currency: 'USD', date: '2026-08-01', status: 'split', pending: 0, created_at: 'x',
+        review_reason: 'amount_changed', amount_changed_from: 5,
+        splitwise_expense_id: 'expShared', description: 'Trip', friend_names: '["Sam"]', amount_each: 6 },
+    ]);
+    const items = await getReviewTransactions();
+    expect(items).toHaveLength(1);
+    expect(items[0].amount).toBe(20);
+    expect(items[0].amount_changed_from).toBe(15);
+    expect(items[0].transaction_ids.slice().sort()).toEqual(['tx1', 'tx2']);
+  });
+
+  test('a combined group with any reversed member reads as reversed', async () => {
+    mockDb.getAllAsync.mockResolvedValueOnce([
+      { id: 'tx1', merchant_name: 'Cafe', amount: 12, currency: 'USD', date: '2026-08-02', status: 'split', pending: 0, created_at: 'x',
+        review_reason: 'amount_changed', amount_changed_from: 10,
+        splitwise_expense_id: 'expShared', description: 'Trip', friend_names: '["Sam"]', amount_each: 6 },
+      { id: 'tx2', merchant_name: 'Uber', amount: 8, currency: 'USD', date: '2026-08-01', status: 'split', pending: 0, created_at: 'x',
+        review_reason: 'reversed', amount_changed_from: null,
+        splitwise_expense_id: 'expShared', description: 'Trip', friend_names: '["Sam"]', amount_each: 6 },
+    ]);
+    const items = await getReviewTransactions();
+    expect(items).toHaveLength(1);
+    // A stranded Splitwise expense outranks a mere amount change.
+    expect(items[0].reason).toBe('reversed');
+  });
+
+  test('surfaces a reversed row with a null amount_changed_from', async () => {
+    mockDb.getAllAsync.mockResolvedValueOnce([
+      { id: 'tx9', merchant_name: 'Cafe', amount: 10, currency: 'USD', date: '2026-08-01', status: 'split', pending: 0, created_at: 'x',
+        review_reason: 'reversed', amount_changed_from: null,
+        splitwise_expense_id: 'exp9', description: null, friend_names: '["Sam"]', amount_each: 5 },
+    ]);
+    const [item] = await getReviewTransactions();
+    expect(item.reason).toBe('reversed');
+    expect(item.amount_changed_from).toBeNull();
+  });
+});
+
+test('clearReview clears the review flag and old amount', async () => {
+  await initDb();
+  await clearReview(['tx1', 'tx2']);
+  expect(mockDb.runAsync).toHaveBeenCalledWith(
+    expect.stringContaining('review_reason = NULL'),
+    ['tx1', 'tx2']
+  );
+});
+
+test('clearReview is a no-op for an empty list', async () => {
+  await initDb();
+  mockDb.runAsync.mockClear();
+  await clearReview([]);
+  expect(mockDb.runAsync).not.toHaveBeenCalled();
+});
+
 describe('vacation CRUD', () => {
   beforeEach(async () => {
-    mockDb.getFirstAsync.mockResolvedValue({ user_version: 4 });
+    mockDb.getFirstAsync.mockResolvedValue({ user_version: 5 });
     await initDb();
   });
 
@@ -469,7 +737,7 @@ describe('vacation CRUD', () => {
 
 describe('vacation transaction capture & history', () => {
   beforeEach(async () => {
-    mockDb.getFirstAsync.mockResolvedValue({ user_version: 4 });
+    mockDb.getFirstAsync.mockResolvedValue({ user_version: 5 });
     await initDb();
   });
 

--- a/mobile/__tests__/lib/db.web.test.ts
+++ b/mobile/__tests__/lib/db.web.test.ts
@@ -9,6 +9,7 @@ import {
   createVacation, getVacations, getVacation, getActiveVacation, startVacation, endVacation, deleteVacation,
   getVacationPendingTransactions, getVacationHistory, assignTransactionsToVacation,
   removeTransactionFromVacation, reconcileVacationStatuses,
+  rekeyTransaction, markTransactionsReversed, getReviewTransactions, clearReview,
 } from '@/lib/db.web';
 import { PlaidTransaction, SplitDecision } from '@/lib/types';
 import { VacationConflictError } from '@/lib/vacationErrors';
@@ -204,6 +205,228 @@ describe('db.web (IndexedDB)', () => {
     await insertSplitDecision(decision('t1', { description: 'Team dinner' }));
     const [item] = await getHistoryTransactions();
     expect(item.merchant_name).toBe('Team dinner');
+  });
+});
+
+describe('rekeyTransaction (IndexedDB)', () => {
+  beforeEach(async () => {
+    (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+    await initDb();
+  });
+
+  it('returns not_found and writes nothing when the old id does not exist', async () => {
+    const result = await rekeyTransaction('missing', plaidTx('new1'));
+    expect(result).toBe('not_found');
+    expect(await getTransactionsByIds(['new1'])).toEqual([]);
+  });
+
+  it('unchanged amount: preserves status/vacation_id/decision, clears pending, sets no review flag', async () => {
+    await upsertTransactions([plaidTx('t1', { amount: 20, pending: true })], 'vac1');
+    await updateTransactionStatus('t1', 'split');
+    await insertSplitDecision(decision('t1', { friend_names: ['Ana'] }));
+
+    const result = await rekeyTransaction('t1', plaidTx('new1', { amount: 20, pending: false }));
+
+    expect(result).toBe('unchanged');
+    expect(await getSplitDecision('t1')).toBeNull();
+    const [row] = await getTransactionsByIds(['new1']);
+    expect(row).toMatchObject({ status: 'split', pending: false, vacation_id: 'vac1' });
+    expect(row.review_reason ?? null).toBeNull();
+    const newDecision = await getSplitDecision('new1');
+    expect(newDecision).toMatchObject({ transaction_id: 'new1', friend_names: ['Ana'] });
+  });
+
+  it('changed amount on a split row: flags amount_changed with the old amount, decision follows to the new id', async () => {
+    await upsertTransactions([plaidTx('t1', { amount: 20 })]);
+    await updateTransactionStatus('t1', 'split');
+    await insertSplitDecision(decision('t1'));
+
+    const result = await rekeyTransaction('t1', plaidTx('new1', { amount: 25 }));
+
+    expect(result).toBe('changed');
+    const [row] = await getTransactionsByIds(['new1']);
+    expect(row.amount).toBe(25);
+    expect(row.review_reason).toBe('amount_changed');
+    expect(row.amount_changed_from).toBe(20);
+    expect(await getSplitDecision('new1')).toMatchObject({ transaction_id: 'new1' });
+  });
+
+  it('changed amount on a new row: no review flag, new amount stored', async () => {
+    await upsertTransactions([plaidTx('t1', { amount: 20 })]);
+
+    const result = await rekeyTransaction('t1', plaidTx('new1', { amount: 25 }));
+
+    expect(result).toBe('changed');
+    const [row] = await getTransactionsByIds(['new1']);
+    expect(row.amount).toBe(25);
+    expect(row.review_reason ?? null).toBeNull();
+  });
+
+  it('changed amount on a skipped row: no review flag, new amount stored', async () => {
+    await upsertTransactions([plaidTx('t1', { amount: 20 })]);
+    await updateTransactionStatus('t1', 'skipped');
+
+    const result = await rekeyTransaction('t1', plaidTx('new1', { amount: 25 }));
+
+    expect(result).toBe('changed');
+    const [row] = await getTransactionsByIds(['new1']);
+    expect(row.review_reason ?? null).toBeNull();
+  });
+
+  it('conflict: a split row already occupying the posted id is never clobbered', async () => {
+    await upsertTransactions([plaidTx('t1', { amount: 20 })]);
+    await updateTransactionStatus('t1', 'split');
+    await insertSplitDecision(decision('t1', { splitwise_expense_id: 'expMine' }));
+    // A different transaction already holds the posted id AND its own expense.
+    await upsertTransactions([plaidTx('new1', { amount: 99 })]);
+    await updateTransactionStatus('new1', 'split');
+    await insertSplitDecision(decision('new1', { splitwise_expense_id: 'expOther' }));
+
+    const result = await rekeyTransaction('t1', plaidTx('new1', { amount: 25 }));
+
+    expect(result).toBe('conflict');
+    // Both rows survive untouched — neither Splitwise expense is stranded.
+    expect(await getTransactionsByIds(['t1'])).toMatchObject([{ amount: 20, status: 'split' }]);
+    expect(await getTransactionsByIds(['new1'])).toMatchObject([{ amount: 99, status: 'split' }]);
+    expect(await getSplitDecision('t1')).toMatchObject({ splitwise_expense_id: 'expMine' });
+    expect(await getSplitDecision('new1')).toMatchObject({ splitwise_expense_id: 'expOther' });
+  });
+
+  it('duplicate: a non-split row occupying the posted id is replaced by the rekeyed row', async () => {
+    await upsertTransactions([plaidTx('t1', { amount: 20 })]);
+    await updateTransactionStatus('t1', 'split');
+    await insertSplitDecision(decision('t1', { splitwise_expense_id: 'expMine', friend_names: ['Ana'] }));
+    // The posted transaction was already inserted as a fresh 'new' row.
+    await upsertTransactions([plaidTx('new1', { amount: 25 })]);
+
+    const result = await rekeyTransaction('t1', plaidTx('new1', { amount: 25 }));
+
+    expect(result).toBe('changed');
+    expect(await getTransactionsByIds(['t1'])).toEqual([]);
+    const rows = await getTransactionsByIds(['new1']);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: 'split', amount: 25, amount_changed_from: 20 });
+    expect(await getSplitDecision('new1')).toMatchObject({ splitwise_expense_id: 'expMine', friend_names: ['Ana'] });
+    // The duplicate is gone from the Transactions list, not left behind.
+    expect(await getNewTransactions()).toEqual([]);
+  });
+});
+
+describe('markTransactionsReversed (IndexedDB)', () => {
+  beforeEach(async () => {
+    (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+    await initDb();
+  });
+
+  it('keeps and flags a split row as reversed', async () => {
+    await upsertTransactions([plaidTx('t1')]);
+    await updateTransactionStatus('t1', 'split');
+    await insertSplitDecision(decision('t1'));
+
+    const kept = await markTransactionsReversed(['t1']);
+
+    expect(kept).toEqual(['t1']);
+    const [row] = await getTransactionsByIds(['t1']);
+    expect(row.review_reason).toBe('reversed');
+    expect(row.status).toBe('split');
+    expect(await getSplitDecision('t1')).not.toBeNull();
+  });
+
+  it('deletes a new/skipped row along with its decision', async () => {
+    await upsertTransactions([plaidTx('t1')]);
+
+    const kept = await markTransactionsReversed(['t1']);
+
+    expect(kept).toEqual([]);
+    expect(await getTransactionsByIds(['t1'])).toEqual([]);
+    expect(await getSplitDecision('t1')).toBeNull();
+  });
+
+  it('is a no-op for an empty list', async () => {
+    const kept = await markTransactionsReversed([]);
+    expect(kept).toEqual([]);
+  });
+});
+
+describe('getReviewTransactions / clearReview (IndexedDB)', () => {
+  beforeEach(async () => {
+    (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+    await initDb();
+  });
+
+  it('returns a single review row with the review reason and amounts', async () => {
+    await upsertTransactions([plaidTx('t1', { amount: 20 })]);
+    await updateTransactionStatus('t1', 'split');
+    await insertSplitDecision(decision('t1', { splitwise_expense_id: 'exp1', friend_names: ['Ana'] }));
+    await rekeyTransaction('t1', plaidTx('new1', { amount: 25 }));
+
+    const items = await getReviewTransactions();
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      id: 'new1', reason: 'amount_changed', amount: 25, amount_changed_from: 20,
+      expense_id: 'exp1', transaction_ids: ['new1'],
+    });
+    expect(items[0].split.friend_names).toEqual(['Ana']);
+  });
+
+  it('groups combined-split members sharing an expense id, summing both amounts', async () => {
+    await upsertTransactions([plaidTx('t1', { amount: 12 }), plaidTx('t2', { amount: 8 })]);
+    await persistCombinedSplit([
+      decision('t1', { splitwise_expense_id: 'expShared' }),
+      decision('t2', { splitwise_expense_id: 'expShared' }),
+    ]);
+    await rekeyTransaction('t1', plaidTx('new1', { amount: 15 }));
+    await rekeyTransaction('t2', plaidTx('new2', { amount: 10 }));
+
+    const items = await getReviewTransactions();
+
+    expect(items).toHaveLength(1);
+    expect(items[0].amount).toBe(25);
+    expect(items[0].amount_changed_from).toBe(20);
+    expect(items[0].transaction_ids.slice().sort()).toEqual(['new1', 'new2']);
+  });
+
+  it('a combined group with any reversed member reads as reversed', async () => {
+    await upsertTransactions([plaidTx('t1', { amount: 12 }), plaidTx('t2', { amount: 8 })]);
+    await persistCombinedSplit([
+      decision('t1', { splitwise_expense_id: 'expShared' }),
+      decision('t2', { splitwise_expense_id: 'expShared' }),
+    ]);
+    await rekeyTransaction('t1', plaidTx('new1', { amount: 15 })); // amount_changed
+    await markTransactionsReversed(['t2']);                        // reversed
+
+    const items = await getReviewTransactions();
+
+    expect(items).toHaveLength(1);
+    // A stranded Splitwise expense outranks a mere amount change.
+    expect(items[0].reason).toBe('reversed');
+  });
+
+  it('surfaces a reversed row with a null amount_changed_from', async () => {
+    await upsertTransactions([plaidTx('t1')]);
+    await updateTransactionStatus('t1', 'split');
+    await insertSplitDecision(decision('t1', { splitwise_expense_id: 'exp9' }));
+    await markTransactionsReversed(['t1']);
+
+    const [item] = await getReviewTransactions();
+    expect(item.reason).toBe('reversed');
+    expect(item.amount_changed_from).toBeNull();
+  });
+
+  it('clearReview clears the review flag and the transaction drops out of the queue', async () => {
+    await upsertTransactions([plaidTx('t1', { amount: 20 })]);
+    await updateTransactionStatus('t1', 'split');
+    await insertSplitDecision(decision('t1'));
+    await rekeyTransaction('t1', plaidTx('new1', { amount: 25 }));
+    expect(await getReviewTransactions()).toHaveLength(1);
+
+    await clearReview(['new1']);
+
+    expect(await getReviewTransactions()).toHaveLength(0);
+    const [row] = await getTransactionsByIds(['new1']);
+    expect(row.review_reason ?? null).toBeNull();
+    expect(row.amount_changed_from ?? null).toBeNull();
   });
 });
 

--- a/mobile/__tests__/stores/transactionStore.test.ts
+++ b/mobile/__tests__/stores/transactionStore.test.ts
@@ -30,6 +30,10 @@ const mockGetNew = db.getNewTransactions as jest.Mock;
 const mockUpsert = db.upsertTransactions as jest.Mock;
 const mockDeleteByIds = db.deleteTransactionsByPlaidIds as jest.Mock;
 const mockUpdateStatus = db.updateTransactionStatus as jest.Mock;
+const mockRekeyTransaction = db.rekeyTransaction as jest.Mock;
+const mockMarkReversed = db.markTransactionsReversed as jest.Mock;
+const mockGetReview = db.getReviewTransactions as jest.Mock;
+const mockClearReview = db.clearReview as jest.Mock;
 const mockFetchTxs = worker.fetchTransactions as jest.Mock;
 const mockSecureGet = SecureStore.getItemAsync as jest.Mock;
 const mockSetNeedsReauth = jest.fn();
@@ -66,6 +70,10 @@ beforeEach(() => {
   mockUpsert.mockResolvedValue(undefined);
   mockDeleteByIds.mockResolvedValue(undefined);
   mockUpdateStatus.mockResolvedValue(undefined);
+  mockRekeyTransaction.mockResolvedValue('not_found');
+  mockMarkReversed.mockResolvedValue([]);
+  mockGetReview.mockResolvedValue([]);
+  mockClearReview.mockResolvedValue(undefined);
   mockGetTokensAndCursors.mockResolvedValue([{ id: 'acct_1', access_token: 'access-token', cursor: 'cur-0' }]);
   mockSaveCursor.mockResolvedValue(undefined);
   mockDeleteExpense.mockResolvedValue(undefined);
@@ -88,7 +96,7 @@ test('load fetches new transactions from DB and updates store', async () => {
   expect(useTransactionStore.getState().transactions[0].id).toBe('tx1');
 });
 
-test('refresh calls worker, upserts added, deletes removed, updates cursor', async () => {
+test('refresh calls worker, upserts added, marks unmatched removed ids reversed, updates cursor', async () => {
   mockFetchTxs.mockResolvedValue(syncPage({
     added: [{ transaction_id: 'tx2', merchant_name: 'Amazon', name: 'AMZN', amount: 29.99, iso_currency_code: 'USD', date: '2026-04-02' }],
     removed: [{ transaction_id: 'tx-old' }],
@@ -96,8 +104,73 @@ test('refresh calls worker, upserts added, deletes removed, updates cursor', asy
   await useTransactionStore.getState().refresh();
   expect(mockFetchTxs).toHaveBeenCalledWith('access-token', 'cur-0');
   expect(mockUpsert).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ transaction_id: 'tx2' })]), null);
-  expect(mockDeleteByIds).toHaveBeenCalledWith(['tx-old']);
+  expect(mockMarkReversed).toHaveBeenCalledWith(['tx-old']);
   expect(mockSaveCursor).toHaveBeenCalledWith('acct_1', 'cur-next');
+});
+
+test('refresh rekeys a posted transaction using its pending_transaction_id before upserting', async () => {
+  mockRekeyTransaction.mockResolvedValue('changed');
+  mockFetchTxs.mockResolvedValue(syncPage({
+    added: [{ transaction_id: 'new1', pending_transaction_id: 'old1', merchant_name: 'Cafe', name: 'CAFE', amount: 12.5, iso_currency_code: 'USD', date: '2026-04-02' }],
+  }));
+  await useTransactionStore.getState().refresh();
+  expect(mockRekeyTransaction).toHaveBeenCalledWith('old1', expect.objectContaining({ transaction_id: 'new1' }));
+  // The rekey must run before the upsert so the posted row inherits status/vacation_id/decision.
+  const rekeyOrder = mockRekeyTransaction.mock.invocationCallOrder[0];
+  const upsertOrder = mockUpsert.mock.invocationCallOrder[0];
+  expect(rekeyOrder).toBeLessThan(upsertOrder);
+});
+
+test('refresh skips rekey for a transaction with no pending_transaction_id', async () => {
+  mockFetchTxs.mockResolvedValue(syncPage({
+    added: [{ transaction_id: 'tx2', merchant_name: 'Amazon', name: 'AMZN', amount: 29.99, iso_currency_code: 'USD', date: '2026-04-02' }],
+  }));
+  await useTransactionStore.getState().refresh();
+  expect(mockRekeyTransaction).not.toHaveBeenCalled();
+});
+
+test('refresh does not mark a rekey-consumed id as reversed', async () => {
+  mockRekeyTransaction.mockResolvedValue('changed');
+  mockFetchTxs.mockResolvedValue(syncPage({
+    added: [{ transaction_id: 'new1', pending_transaction_id: 'old1', merchant_name: 'Cafe', name: 'CAFE', amount: 12.5, iso_currency_code: 'USD', date: '2026-04-02' }],
+    removed: [{ transaction_id: 'old1' }],
+  }));
+  await useTransactionStore.getState().refresh();
+  expect(mockMarkReversed).toHaveBeenCalledWith([]);
+});
+
+test('refresh does not mark an id as reversed when it reappears in this page\'s added/modified', async () => {
+  // Some institutions reuse transaction ids; deleting here would drop the row we just kept.
+  mockFetchTxs.mockResolvedValue(syncPage({
+    added: [{ transaction_id: 'dup1', merchant_name: 'Cafe', name: 'CAFE', amount: 5, iso_currency_code: 'USD', date: '2026-04-02' }],
+    removed: [{ transaction_id: 'dup1' }],
+  }));
+  await useTransactionStore.getState().refresh();
+  expect(mockMarkReversed).toHaveBeenCalledWith([]);
+});
+
+test('refresh does not rekey when rekeyTransaction reports not_found', async () => {
+  mockRekeyTransaction.mockResolvedValue('not_found');
+  mockFetchTxs.mockResolvedValue(syncPage({
+    added: [{ transaction_id: 'new1', pending_transaction_id: 'old1', merchant_name: 'Cafe', name: 'CAFE', amount: 12.5, iso_currency_code: 'USD', date: '2026-04-02' }],
+    removed: [{ transaction_id: 'old1' }],
+  }));
+  await useTransactionStore.getState().refresh();
+  // 'not_found' means nothing was consumed, so the removed id still gets marked/deleted.
+  expect(mockMarkReversed).toHaveBeenCalledWith(['old1']);
+});
+
+test('refresh leaves the old row alone when rekeyTransaction reports conflict', async () => {
+  // A split row already occupies the posted id, so the rekey was refused. The
+  // pending row still holds its own Splitwise expense — marking it reversed
+  // would wrongly prompt to delete a live expense, so it must be left as is.
+  mockRekeyTransaction.mockResolvedValue('conflict');
+  mockFetchTxs.mockResolvedValue(syncPage({
+    added: [{ transaction_id: 'new1', pending_transaction_id: 'old1', merchant_name: 'Cafe', name: 'CAFE', amount: 12.5, iso_currency_code: 'USD', date: '2026-04-02' }],
+    removed: [{ transaction_id: 'old1' }],
+  }));
+  await useTransactionStore.getState().refresh();
+  expect(mockMarkReversed).toHaveBeenCalledWith([]);
 });
 
 test('refresh follows has_more pages and saves the final cursor', async () => {
@@ -246,4 +319,23 @@ test('commitCombinedSplit persists rows atomically then drops members from the l
   await useTransactionStore.getState().commitCombinedSplit(decisions);
   expect(mockPersistCombined).toHaveBeenCalledWith(decisions);
   expect(useTransactionStore.getState().transactions.map((t) => t.id)).toEqual(['txC']);
+});
+
+test('loadReview fetches review items from DB and updates the store', async () => {
+  const reviewItem = {
+    id: 'tx1', merchant_name: 'Cafe', amount: 12.5, amount_changed_from: 10, currency: 'USD',
+    date: '2026-04-01', reason: 'amount_changed' as const, split: { friend_names: ['Sam'], amount_each: 6.25 },
+    expense_id: 'exp1', transaction_ids: ['tx1'],
+  };
+  mockGetReview.mockResolvedValue([reviewItem]);
+  await useTransactionStore.getState().loadReview();
+  expect(useTransactionStore.getState().review).toEqual([reviewItem]);
+});
+
+test('resolveReview clears the review flag then reloads the queue', async () => {
+  mockGetReview.mockResolvedValue([]);
+  await useTransactionStore.getState().resolveReview(['tx1', 'tx2']);
+  expect(mockClearReview).toHaveBeenCalledWith(['tx1', 'tx2']);
+  expect(mockGetReview).toHaveBeenCalled();
+  expect(useTransactionStore.getState().review).toEqual([]);
 });

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -12,14 +12,36 @@ import { ReauthBanner } from '@/components/ReauthBanner';
 import { OfflineBanner } from '@/components/OfflineBanner';
 import { FriendPickerSheet } from '@/components/FriendPickerSheet';
 import { useToast } from '@/components/ToastProvider';
-import { Transaction } from '@/lib/types';
+import { showDialog } from '@/lib/dialog';
+import { getSplitDecision, getTransactionsByIds, deleteTransactionsByPlaidIds } from '@/lib/db';
+import { Transaction, SplitDecision, ReviewItem } from '@/lib/types';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { Colors, Spacing, Radius, Shadow } from '@/lib/theme';
+import { Colors, Spacing, Radius, Shadow, merchantColor } from '@/lib/theme';
+
+// Adapt a review item back to a Transaction for the picker's single-edit
+// flow. amount/currency/date come from the item (already the posted values
+// after rekeying); pending/created_at don't affect the expense, so safe
+// defaults are fine. Mirrors history.tsx's asTransaction.
+function reviewItemAsTransaction(item: ReviewItem): Transaction {
+  return {
+    id: item.transaction_ids[0],
+    merchant_name: item.merchant_name,
+    amount: item.amount,
+    currency: item.currency,
+    date: item.date,
+    status: 'split',
+    pending: false,
+    created_at: item.date,
+  };
+}
 
 export default function NewTransactionsScreen() {
   const router = useRouter();
   const topInset = Constants.statusBarHeight;
-  const { transactions, isLoading, load, refresh, skip } = useTransactionStore();
+  const {
+    transactions, isLoading, review, load, refresh, skip, loadReview, resolveReview,
+    deleteSplit, deleteCombinedSplit,
+  } = useTransactionStore();
   const needsReauth = usePlaidStore((s) => s.needs_reauth);
   const [isConnected, setIsConnected] = useState(true);
   const [selected, setSelected] = useState<Transaction | null>(null);
@@ -30,10 +52,14 @@ export default function NewTransactionsScreen() {
   const [combineTxs, setCombineTxs] = useState<Transaction[] | null>(null);
   const [pickerToken, setPickerToken] = useState(0);
   const [pendingPresent, setPendingPresent] = useState(false);
+  const [editDecision, setEditDecision] = useState<SplitDecision | null>(null);
+  const [pickerMode, setPickerMode] = useState<'create' | 'edit'>('create');
+  const [reviewResolveIds, setReviewResolveIds] = useState<string[] | null>(null);
 
   useEffect(() => {
     load();
-    refresh();
+    loadReview();
+    refresh().then(() => loadReview());
     const unsub = NetInfo.addEventListener((state) => setIsConnected(!!state.isConnected));
     return unsub;
   }, []);
@@ -50,6 +76,9 @@ export default function NewTransactionsScreen() {
 
   function openSheet(tx: Transaction) {
     setCombineTxs(null);
+    setEditDecision(null);
+    setPickerMode('create');
+    setReviewResolveIds(null);
     setSelected(tx);
     setPickerToken((t) => t + 1);
     setPendingPresent(true);
@@ -82,13 +111,85 @@ export default function NewTransactionsScreen() {
       return;
     }
     setSelected(null);
+    setEditDecision(null);
+    setPickerMode('create');
+    setReviewResolveIds(null);
     setCombineTxs(members);
     setPickerToken((t) => t + 1);
     setPendingPresent(true);
   }
 
+  async function openReviewEdit(item: ReviewItem) {
+    if (item.transaction_ids.length > 1) {
+      const [members, decision] = await Promise.all([
+        getTransactionsByIds(item.transaction_ids),
+        getSplitDecision(item.transaction_ids[0]),
+      ]);
+      if (!decision || members.length === 0) {
+        toast.show('Could not load this split. Please try again.', 'error');
+        return;
+      }
+      setSelected(null);
+      setCombineTxs(members);
+      setEditDecision(decision);
+    } else {
+      const decision = await getSplitDecision(item.transaction_ids[0]);
+      if (!decision) {
+        toast.show('Could not load this split. Please try again.', 'error');
+        return;
+      }
+      setCombineTxs(null);
+      setSelected(reviewItemAsTransaction(item));
+      setEditDecision(decision);
+    }
+    setPickerMode('edit');
+    setReviewResolveIds(item.transaction_ids);
+    setPickerToken((t) => t + 1);
+    setPendingPresent(true);
+  }
+
+  function openReviewReversed(item: ReviewItem) {
+    const isCombined = item.transaction_ids.length > 1;
+    const label = isCombined ? `${item.transaction_ids.length} transactions` : item.merchant_name;
+    showDialog(
+      'Charge reversed',
+      `The pending charge for ${label} never posted. This removes the Splitwise expense and clears it from your review queue.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete expense',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              if (isCombined) {
+                await deleteCombinedSplit(item.transaction_ids, item.expense_id);
+              } else {
+                await deleteSplit(item.transaction_ids[0], item.expense_id);
+              }
+              await deleteTransactionsByPlaidIds(item.transaction_ids);
+              await load();
+              await loadReview();
+              toast.show('Reversed charge removed', 'success');
+            } catch {
+              toast.show('Failed to remove. Please try again.', 'error');
+            }
+          },
+        },
+      ]
+    );
+  }
+
   function handleSplitSuccess(amountEach: number) {
     sheetRef.current?.dismiss();
+    if (reviewResolveIds) {
+      const ids = reviewResolveIds;
+      setReviewResolveIds(null);
+      setEditDecision(null);
+      setPickerMode('create');
+      resolveReview(ids);
+      toast.show('Split updated', 'success');
+      return;
+    }
     cancelSelect();
     toast.show(`Added! Others owe you $${amountEach.toFixed(2)}`, 'success');
   }
@@ -97,7 +198,12 @@ export default function NewTransactionsScreen() {
     router.push('/(auth)/bank-connect');
   }
 
-  const isEmptyAndLoaded = !isLoading && transactions.length === 0;
+  async function handleRefresh() {
+    await refresh();
+    await loadReview();
+  }
+
+  const isEmptyAndLoaded = !isLoading && transactions.length === 0 && review.length === 0;
   const listExtraData = useMemo(() => ({ selectMode, selectedIds }), [selectMode, selectedIds]);
 
   return (
@@ -139,10 +245,14 @@ export default function NewTransactionsScreen() {
           refreshControl={
             <RefreshControl
               refreshing={isLoading}
-              onRefresh={refresh}
+              onRefresh={handleRefresh}
               tintColor={Colors.primary}
             />
           }
+          ListHeaderComponent={
+            <ReviewSection items={review} onAmountChanged={openReviewEdit} onReversed={openReviewReversed} />
+          }
+          ListEmptyComponent={transactions.length === 0 ? <EmptyState /> : null}
           renderItem={({ item }) => (
             <TransactionRow
               transaction={item}
@@ -161,6 +271,8 @@ export default function NewTransactionsScreen() {
         ref={sheetRef}
         transaction={selected}
         combineTransactions={combineTxs ?? undefined}
+        mode={pickerMode}
+        editDecision={editDecision}
         openToken={pickerToken}
         onSuccess={handleSplitSuccess}
       />
@@ -221,6 +333,73 @@ function LoadingSkeleton() {
   );
 }
 
+// Pinned "Needs review" section rendered as the FlatList's ListHeaderComponent
+// (not a nested list), per the product decision: transactions whose
+// pending→posted transition needs attention surface here, not in a new tab.
+function ReviewSection({
+  items,
+  onAmountChanged,
+  onReversed,
+}: {
+  items: ReviewItem[];
+  onAmountChanged: (item: ReviewItem) => void;
+  onReversed: (item: ReviewItem) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <View style={styles.reviewSection}>
+      <Text style={styles.reviewHeading}>Needs review · {items.length}</Text>
+      {items.map((item) => (
+        <ReviewRow
+          key={item.id}
+          item={item}
+          onPress={() => (item.reason === 'amount_changed' ? onAmountChanged(item) : onReversed(item))}
+        />
+      ))}
+    </View>
+  );
+}
+
+function ReviewRow({ item, onPress }: { item: ReviewItem; onPress: () => void }) {
+  const initial = (item.merchant_name ?? '?')[0].toUpperCase();
+  const avatarColor = merchantColor(item.merchant_name ?? '?');
+  const isAmountChanged = item.reason === 'amount_changed';
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.reviewCard, pressed && styles.reviewCardPressed]}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={
+        isAmountChanged
+          ? `Review amount change for ${item.merchant_name}`
+          : `Review reversed charge for ${item.merchant_name}`
+      }
+    >
+      <View style={[styles.avatar, { backgroundColor: avatarColor + '18' }]}>
+        <Text style={[styles.avatarText, { color: avatarColor }]}>{initial}</Text>
+      </View>
+      <View style={styles.info}>
+        <Text style={styles.merchant} numberOfLines={1}>{item.merchant_name}</Text>
+        {isAmountChanged ? (
+          <Text style={styles.reviewDetail}>
+            ${(item.amount_changed_from ?? 0).toFixed(2)} → ${item.amount.toFixed(2)}
+          </Text>
+        ) : (
+          <Text style={styles.reviewDetail}>Charge reversed</Text>
+        )}
+        {item.split.friend_names.length > 0 && (
+          <View style={styles.reviewSplitBadge}>
+            <Ionicons name="people-outline" size={11} color={Colors.textSecondary} style={{ marginRight: 3 }} />
+            <Text style={styles.reviewSplitText}>{item.split.friend_names.join(', ')}</Text>
+          </View>
+        )}
+      </View>
+      <Ionicons name="chevron-forward" size={18} color={Colors.textTertiary} />
+    </Pressable>
+  );
+}
+
 const styles = StyleSheet.create({
   root: { flex: 1, backgroundColor: Colors.bg },
 
@@ -261,6 +440,63 @@ const styles = StyleSheet.create({
   },
 
   list: { padding: Spacing.lg, gap: 10 },
+
+  reviewSection: {
+    marginBottom: Spacing.sm,
+    gap: 10,
+  },
+  reviewHeading: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: Colors.warning,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    marginBottom: 2,
+  },
+  reviewCard: {
+    backgroundColor: Colors.warningLight,
+    borderRadius: Radius.lg,
+    padding: Spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    ...Shadow.sm,
+  },
+  reviewCardPressed: { backgroundColor: Colors.surfaceMuted },
+  reviewDetail: {
+    fontSize: 12,
+    color: Colors.textSecondary,
+    fontWeight: '600',
+    marginTop: 2,
+  },
+  reviewSplitBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  reviewSplitText: {
+    fontSize: 12,
+    color: Colors.textSecondary,
+    fontWeight: '500',
+  },
+
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: Radius.md,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: Spacing.md,
+  },
+  avatarText: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  info: { flex: 1, marginRight: Spacing.sm },
+  merchant: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: Colors.textPrimary,
+  },
 
   emptyContainer: {
     flex: 1,

--- a/mobile/lib/db.ts
+++ b/mobile/lib/db.ts
@@ -1,6 +1,6 @@
 // mobile/lib/db.ts
 import * as SQLite from 'expo-sqlite';
-import { Transaction, PlaidTransaction, SplitDecision, TransactionStatus, HistoryItem } from '@/lib/types';
+import { Transaction, PlaidTransaction, SplitDecision, TransactionStatus, HistoryItem, ReviewItem, ReviewReason, RekeyResult } from '@/lib/types';
 import { Vacation, CreateVacationInput, VacationStatus } from '@/lib/types';
 import { generateId } from '@/lib/id';
 import { VacationConflictError } from '@/lib/vacationErrors';
@@ -72,11 +72,18 @@ export async function initDb(): Promise<void> {
     // fresh installs.
     await _db.execAsync(`ALTER TABLE transactions ADD COLUMN vacation_id TEXT REFERENCES vacations(id);`);
   }
+  if (version < 5) {
+    // Same rationale as vacation_id above: review_reason/amount_changed_from
+    // are not in the base `version < 1` CREATE TABLE, so these ALTERs must
+    // run ungated so a fresh install (version 0) gets the columns too.
+    await _db.execAsync(`ALTER TABLE transactions ADD COLUMN review_reason TEXT;`);
+    await _db.execAsync(`ALTER TABLE transactions ADD COLUMN amount_changed_from REAL;`);
+  }
   // Only stamp when a migration actually ran, to avoid a file-header write on
   // every cold start. Keep the literal in sync with the highest block above:
   // when adding a `version < N` block, bump this to N.
-  if (version < 4) {
-    await _db.execAsync(`PRAGMA user_version = 4;`);
+  if (version < 5) {
+    await _db.execAsync(`PRAGMA user_version = 5;`);
   }
 }
 
@@ -170,6 +177,85 @@ export async function getHistoryTransactions(): Promise<HistoryItem[]> {
     []
   );
   return groupHistoryRows(rows);
+}
+
+type ReviewRow = Transaction & {
+  splitwise_expense_id: string | null;
+  friend_names: string | null;
+  amount_each: number | null;
+};
+
+// null + null stays null (nothing to show); otherwise nulls contribute 0, so
+// a combined split where only some members changed amount still sums correctly.
+function addNullable(a: number | null, b: number | null): number | null {
+  if (a === null && b === null) return null;
+  return (a ?? 0) + (b ?? 0);
+}
+
+// Groups review-eligible rows by shared Splitwise expense id, exactly as
+// groupHistoryRows does for history — one row per expense, amounts summed.
+function groupReviewRows(rows: ReviewRow[]): ReviewItem[] {
+  const items: ReviewItem[] = [];
+  const groups = new Map<string, ReviewItem>();
+
+  for (const r of rows) {
+    const key = r.splitwise_expense_id ?? r.id;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.amount += r.amount;
+      existing.amount_changed_from = addNullable(existing.amount_changed_from, r.amount_changed_from ?? null);
+      existing.transaction_ids.push(r.id);
+      // Mixed reasons across members of one expense: 'reversed' wins. A
+      // stranded Splitwise expense needs deleting, which outranks (and would
+      // otherwise be hidden behind) a mere amount change on a sibling member.
+      if (r.review_reason === 'reversed') existing.reason = 'reversed';
+    } else {
+      const item: ReviewItem = {
+        id: r.id,
+        merchant_name: r.merchant_name,
+        amount: r.amount,
+        amount_changed_from: r.amount_changed_from ?? null,
+        currency: r.currency,
+        date: r.date,
+        reason: (r.review_reason as ReviewReason) ?? 'amount_changed',
+        split: {
+          friend_names: r.friend_names ? JSON.parse(r.friend_names) : [],
+          amount_each: r.amount_each ?? 0,
+        },
+        expense_id: r.splitwise_expense_id ?? r.id,
+        transaction_ids: [r.id],
+      };
+      groups.set(key, item);
+      items.push(item);
+    }
+  }
+
+  for (const g of groups.values()) {
+    if (g.transaction_ids.length > 1) g.id = g.expense_id;
+  }
+
+  return items;
+}
+
+export async function getReviewTransactions(): Promise<ReviewItem[]> {
+  const rows = await db().getAllAsync<ReviewRow>(
+    `SELECT t.*, s.splitwise_expense_id, s.friend_names, s.amount_each
+     FROM transactions t
+     LEFT JOIN split_decisions s ON s.transaction_id = t.id
+     WHERE t.review_reason IS NOT NULL
+     ORDER BY t.date DESC`,
+    []
+  );
+  return groupReviewRows(rows);
+}
+
+export async function clearReview(transactionIds: string[]): Promise<void> {
+  if (transactionIds.length === 0) return;
+  const placeholders = transactionIds.map(() => '?').join(',');
+  await db().runAsync(
+    `UPDATE transactions SET review_reason = NULL, amount_changed_from = NULL WHERE id IN (${placeholders})`,
+    transactionIds
+  );
 }
 
 export async function getVacationPendingTransactions(vacationId: string): Promise<Transaction[]> {
@@ -280,6 +366,13 @@ export async function upsertTransactions(txs: PlaidTransaction[], activeVacation
 export async function deleteTransactionsByPlaidIds(ids: string[]): Promise<void> {
   if (ids.length === 0) return;
   const placeholders = ids.map(() => '?').join(',');
+  // Native never enables `PRAGMA foreign_keys`, so the ON DELETE CASCADE on
+  // split_decisions.transaction_id is inert — delete explicitly, mirroring
+  // db.web.ts's explicit DECISION_STORE delete.
+  await db().runAsync(
+    `DELETE FROM split_decisions WHERE transaction_id IN (${placeholders})`,
+    ids
+  );
   await db().runAsync(
     `DELETE FROM transactions WHERE id IN (${placeholders})`,
     ids
@@ -291,6 +384,104 @@ export async function updateTransactionStatus(id: string, status: TransactionSta
     `UPDATE transactions SET status = ? WHERE id = ?`,
     [status, id]
   );
+}
+
+// Rekey a pending transaction's row to the id Plaid assigns once it posts.
+// Plaid's transaction_id is NOT stable across the pending → posted
+// transition: the posted transaction arrives with a brand-new id and only
+// `pending_transaction_id` links it back to the old one. Without this, the
+// posted transaction would insert as a fresh 'new' row and the pending row
+// (holding the split decision) would get deleted by the sync's `removed`
+// list — orphaning the Splitwise expense.
+//
+// One transaction: load the old row, rewrite its primary key and mutable
+// fields in place, and carry the split_decisions row along to the new id.
+// status/vacation_id are preserved by construction (never included in the
+// UPDATE). review_reason/amount_changed_from are only set when the amount
+// actually changed on a row that was already 'split' — a 'new' or 'skipped'
+// row has no Splitwise expense to reconcile, so it just takes the new amount.
+export async function rekeyTransaction(
+  oldId: string,
+  posted: PlaidTransaction
+): Promise<RekeyResult> {
+  const d = db();
+  let result: RekeyResult = 'not_found';
+  await d.withTransactionAsync(async () => {
+    const row = await d.getFirstAsync<{ id: string; amount: number; status: TransactionStatus }>(
+      `SELECT id, amount, status FROM transactions WHERE id = ?`,
+      [oldId]
+    );
+    if (!row) {
+      result = 'not_found';
+      return;
+    }
+    // A row can already occupy the posted id when Plaid inserts the posted
+    // transaction in one sync page and only reports its pending_transaction_id
+    // in a later one. Rewriting the primary key onto an occupied id would
+    // violate PRIMARY KEY and abort the whole sync, so resolve it here.
+    if (posted.transaction_id !== oldId) {
+      const occupant = await d.getFirstAsync<{ id: string; status: TransactionStatus }>(
+        `SELECT id, status FROM transactions WHERE id = ?`,
+        [posted.transaction_id]
+      );
+      if (occupant) {
+        // An occupant that is itself 'split' has its own Splitwise expense.
+        // Clobbering it would strand that expense, so leave both rows alone
+        // and let the caller keep the old row rather than destroy data.
+        if (occupant.status === 'split') {
+          result = 'conflict';
+          return;
+        }
+        // Otherwise it's the duplicate 'new'/'skipped' row this rekey is meant
+        // to supersede — no expense attached, safe to drop.
+        await deleteTransactionsByPlaidIds([posted.transaction_id]);
+      }
+    }
+    const name = posted.merchant_name ?? posted.name;
+    const changed = Math.round(row.amount * 100) !== Math.round(posted.amount * 100);
+    const reviewReason: ReviewReason | null = changed && row.status === 'split' ? 'amount_changed' : null;
+    const amountChangedFrom = reviewReason ? row.amount : null;
+
+    await d.runAsync(
+      `UPDATE transactions SET id = ?, merchant_name = ?, amount = ?, date = ?, pending = 0,
+       review_reason = ?, amount_changed_from = ? WHERE id = ?`,
+      [posted.transaction_id, name, posted.amount, posted.date, reviewReason, amountChangedFrom, oldId]
+    );
+    await d.runAsync(
+      `UPDATE split_decisions SET transaction_id = ? WHERE transaction_id = ?`,
+      [posted.transaction_id, oldId]
+    );
+    result = changed ? 'changed' : 'unchanged';
+  });
+  return result;
+}
+
+// A pending split transaction Plaid reports as `removed` without a matching
+// `added`/`modified` posting is a reversal: the charge never posted. A
+// 'split' row is kept and flagged so the queue can offer to delete the now-
+// stranded Splitwise expense; a 'new'/'skipped' row has no expense to
+// reconcile, so it's deleted today (mirrors the old unconditional delete).
+// Returns the ids that were kept, for logging/testing.
+export async function markTransactionsReversed(ids: string[]): Promise<string[]> {
+  if (ids.length === 0) return [];
+  const d = db();
+  const rows = await getTransactionsByIds(ids);
+  const keepIds = rows.filter((r) => r.status === 'split').map((r) => r.id);
+  const keepSet = new Set(keepIds);
+  const deleteIds = ids.filter((id) => !keepSet.has(id));
+  await d.withTransactionAsync(async () => {
+    if (keepIds.length > 0) {
+      const placeholders = keepIds.map(() => '?').join(',');
+      await d.runAsync(
+        `UPDATE transactions SET review_reason = 'reversed' WHERE id IN (${placeholders})`,
+        keepIds
+      );
+    }
+    if (deleteIds.length > 0) {
+      await deleteTransactionsByPlaidIds(deleteIds);
+    }
+  });
+  return keepIds;
 }
 
 export async function getSplitDecision(transactionId: string): Promise<SplitDecision | null> {

--- a/mobile/lib/db.web.ts
+++ b/mobile/lib/db.web.ts
@@ -3,7 +3,7 @@
 // expo-sqlite's wasm build was rejected because it requires COOP/COEP
 // cross-origin isolation, which breaks Plaid Link popups (see design spec).
 import {
-  Transaction, PlaidTransaction, SplitDecision, TransactionStatus, HistoryItem,
+  Transaction, PlaidTransaction, SplitDecision, TransactionStatus, HistoryItem, ReviewItem, ReviewReason, RekeyResult,
 } from '@/lib/types';
 import { Vacation, CreateVacationInput, VacationStatus } from '@/lib/types';
 import { generateId } from '@/lib/id';
@@ -153,6 +153,77 @@ export async function getHistoryTransactions(): Promise<HistoryItem[]> {
   return groupHistoryRows(rows, decisions);
 }
 
+// null + null stays null (nothing to show); otherwise nulls contribute 0, so
+// a combined split where only some members changed amount still sums correctly.
+function addNullable(a: number | null, b: number | null): number | null {
+  if (a === null && b === null) return null;
+  return (a ?? 0) + (b ?? 0);
+}
+
+// Groups review-eligible rows by shared Splitwise expense id, exactly as
+// groupHistoryRows does for history — one row per expense, amounts summed.
+function groupReviewRows(rows: Transaction[], decisions: SplitDecision[]): ReviewItem[] {
+  const byTxId = new Map(decisions.map((d) => [d.transaction_id, d]));
+  const items: ReviewItem[] = [];
+  const groups = new Map<string, ReviewItem>();
+
+  for (const t of rows) {
+    const d = byTxId.get(t.id);
+    const key = d?.splitwise_expense_id ?? t.id;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.amount += t.amount;
+      existing.amount_changed_from = addNullable(existing.amount_changed_from, t.amount_changed_from ?? null);
+      existing.transaction_ids.push(t.id);
+      // Mixed reasons across members of one expense: 'reversed' wins, matching
+      // lib/db.ts's groupReviewRows.
+      if (t.review_reason === 'reversed') existing.reason = 'reversed';
+    } else {
+      const item: ReviewItem = {
+        id: t.id,
+        merchant_name: t.merchant_name,
+        amount: t.amount,
+        amount_changed_from: t.amount_changed_from ?? null,
+        currency: t.currency,
+        date: t.date,
+        reason: (t.review_reason as ReviewReason) ?? 'amount_changed',
+        split: { friend_names: d?.friend_names ?? [], amount_each: d?.amount_each ?? 0 },
+        expense_id: d?.splitwise_expense_id ?? t.id,
+        transaction_ids: [t.id],
+      };
+      groups.set(key, item);
+      items.push(item);
+    }
+  }
+
+  for (const g of groups.values()) {
+    if (g.transaction_ids.length > 1) g.id = g.expense_id;
+  }
+
+  return items;
+}
+
+export async function getReviewTransactions(): Promise<ReviewItem[]> {
+  const tx = db().transaction([TX_STORE, DECISION_STORE]);
+  const [all, decisions] = await Promise.all([
+    req(tx.objectStore(TX_STORE).getAll() as IDBRequest<Transaction[]>),
+    req(tx.objectStore(DECISION_STORE).getAll() as IDBRequest<SplitDecision[]>),
+  ]);
+  const rows = all.filter((t) => t.review_reason != null).sort(byDateDesc);
+  return groupReviewRows(rows, decisions);
+}
+
+export async function clearReview(transactionIds: string[]): Promise<void> {
+  if (transactionIds.length === 0) return;
+  const tx = db().transaction(TX_STORE, 'readwrite');
+  const store = tx.objectStore(TX_STORE);
+  for (const id of transactionIds) {
+    const existing = await req(store.get(id) as IDBRequest<Transaction | undefined>);
+    if (existing) store.put({ ...existing, review_reason: null, amount_changed_from: null });
+  }
+  await done(tx);
+}
+
 export async function getVacationPendingTransactions(vacationId: string): Promise<Transaction[]> {
   const all = await req(db().transaction(TX_STORE).objectStore(TX_STORE).getAll() as IDBRequest<Transaction[]>);
   return all.filter((t) => t.status === 'new' && t.vacation_id === vacationId).sort(byDateDesc);
@@ -289,6 +360,87 @@ export async function updateTransactionStatus(id: string, status: TransactionSta
   const existing = await req(store.get(id) as IDBRequest<Transaction | undefined>);
   if (existing) store.put({ ...existing, status });
   await done(tx);
+}
+
+// Mirrors lib/db.ts's rekeyTransaction — see that function's comment for why
+// this exists. Deletes the old key and re-puts under the new key in both
+// stores, inside one readwrite transaction spanning both so a failure can't
+// leave the transaction row and its decision pointing at different ids.
+export async function rekeyTransaction(
+  oldId: string,
+  posted: PlaidTransaction
+): Promise<RekeyResult> {
+  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const txStore = tx.objectStore(TX_STORE);
+  const decStore = tx.objectStore(DECISION_STORE);
+  // Invariant: only await IDB requests belonging to this txn, so it stays active.
+  const existing = await req(txStore.get(oldId) as IDBRequest<Transaction | undefined>);
+  if (!existing) {
+    await done(tx);
+    return 'not_found';
+  }
+  // Same collision case the native implementation guards — see lib/db.ts. A
+  // put() here would silently overwrite rather than throw, which is worse:
+  // it would strand the occupant's Splitwise expense with no error.
+  if (posted.transaction_id !== oldId) {
+    const occupant = await req(
+      txStore.get(posted.transaction_id) as IDBRequest<Transaction | undefined>,
+    );
+    if (occupant && occupant.status === 'split') {
+      await done(tx);
+      return 'conflict';
+    }
+    // A non-split occupant is the duplicate this rekey supersedes; the put()
+    // below overwrites it, and its (nonexistent) decision needs no cleanup.
+  }
+  const decisionRow = await req(decStore.get(oldId) as IDBRequest<SplitDecision | undefined>);
+
+  const name = posted.merchant_name ?? posted.name;
+  const changed = Math.round(existing.amount * 100) !== Math.round(posted.amount * 100);
+  const reviewReason: ReviewReason | null = changed && existing.status === 'split' ? 'amount_changed' : null;
+  const amountChangedFrom = reviewReason ? existing.amount : null;
+
+  txStore.delete(oldId);
+  txStore.put({
+    ...existing,
+    id: posted.transaction_id,
+    merchant_name: name,
+    amount: posted.amount,
+    date: posted.date,
+    pending: false,
+    review_reason: reviewReason,
+    amount_changed_from: amountChangedFrom,
+  } satisfies Transaction);
+
+  if (decisionRow) {
+    decStore.delete(oldId);
+    decStore.put({ ...decisionRow, transaction_id: posted.transaction_id });
+  }
+
+  await done(tx);
+  return changed ? 'changed' : 'unchanged';
+}
+
+// Mirrors lib/db.ts's markTransactionsReversed.
+export async function markTransactionsReversed(ids: string[]): Promise<string[]> {
+  if (ids.length === 0) return [];
+  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const txStore = tx.objectStore(TX_STORE);
+  const decStore = tx.objectStore(DECISION_STORE);
+  const kept: string[] = [];
+  // Invariant: only await IDB requests belonging to this txn inside the loop.
+  for (const id of ids) {
+    const existing = await req(txStore.get(id) as IDBRequest<Transaction | undefined>);
+    if (existing && existing.status === 'split') {
+      txStore.put({ ...existing, review_reason: 'reversed' as ReviewReason });
+      kept.push(id);
+    } else {
+      txStore.delete(id);
+      decStore.delete(id);
+    }
+  }
+  await done(tx);
+  return kept;
 }
 
 export async function getSplitDecision(transactionId: string): Promise<SplitDecision | null> {

--- a/mobile/lib/types.ts
+++ b/mobile/lib/types.ts
@@ -2,6 +2,13 @@
 
 export type TransactionStatus = 'new' | 'split' | 'skipped';
 
+export type ReviewReason = 'amount_changed' | 'reversed';
+
+// Outcome of rekeying a pending transaction's row onto its posted Plaid id.
+// 'conflict' = another transaction already occupies the posted id and holds its
+// own Splitwise expense; both rows are left untouched rather than clobbered.
+export type RekeyResult = 'unchanged' | 'changed' | 'not_found' | 'conflict';
+
 export interface Transaction {
   id: string;            // Plaid transaction_id
   merchant_name: string;
@@ -12,6 +19,8 @@ export interface Transaction {
   pending: boolean;
   created_at: string;    // ISO-8601 datetime; used for 6-month prune
   vacation_id?: string | null; // set while assigned to a vacation
+  review_reason?: ReviewReason | null; // set when a pending→posted transition needs user attention
+  amount_changed_from?: number | null; // previous amount, for "was $X → now $Y"; set alongside review_reason='amount_changed'
 }
 
 export interface SplitDecision {
@@ -44,6 +53,11 @@ export interface PlaidTransaction {
   iso_currency_code: string | null;
   date: string;
   pending: boolean;
+  // When Plaid transitions a pending transaction to posted, the posted
+  // transaction carries a new transaction_id and points back at the old
+  // (now-removed) pending id here. Used to rekey the local row instead of
+  // treating the posted transaction as brand new.
+  pending_transaction_id?: string | null;
 }
 
 export interface PlaidTransactionsResponse {
@@ -72,6 +86,23 @@ export interface HistoryItem {
   status: TransactionStatus;
   split?: { friend_names: string[]; amount_each: number };
   combined?: { expense_id: string; transaction_ids: string[]; count: number };
+}
+
+// A row in the "Needs review" queue: a transaction whose pending→posted
+// transition needs user attention (amount changed, or the pending charge was
+// reversed and never posted). A combined split's members collapse into a
+// single row keyed by the shared Splitwise expense, same as HistoryItem.
+export interface ReviewItem {
+  id: string;                  // tx id for single rows; expense id for combined
+  merchant_name: string;
+  amount: number;              // new total (summed for combined)
+  amount_changed_from: number | null;  // old total (summed for combined)
+  currency: string;
+  date: string;
+  reason: ReviewReason;
+  split: { friend_names: string[]; amount_each: number };
+  expense_id: string;
+  transaction_ids: string[];   // 1 entry for single, N for combined
 }
 
 export type VacationStatus = 'draft' | 'active' | 'ended';

--- a/mobile/stores/transactionStore.ts
+++ b/mobile/stores/transactionStore.ts
@@ -5,19 +5,23 @@ import { deleteExpense } from '@/lib/splitwise';
 import {
   getNewTransactions,
   upsertTransactions,
-  deleteTransactionsByPlaidIds,
   updateTransactionStatus,
   deleteSplitDecision,
   persistCombinedSplit,
   revertCombinedSplit,
+  rekeyTransaction,
+  markTransactionsReversed,
+  getReviewTransactions,
+  clearReview,
 } from '@/lib/db';
-import { Transaction, SplitDecision } from '@/lib/types';
+import { Transaction, SplitDecision, ReviewItem } from '@/lib/types';
 import { usePlaidStore } from '@/stores/plaidStore';
 import { useVacationStore } from '@/stores/vacationStore';
 
 interface TransactionState {
   transactions: Transaction[];
   isLoading: boolean;
+  review: ReviewItem[];
   load: () => Promise<void>;
   refresh: () => Promise<void>;
   skip: (id: string) => Promise<void>;
@@ -25,11 +29,14 @@ interface TransactionState {
   commitCombinedSplit: (decisions: SplitDecision[]) => Promise<void>;
   deleteSplit: (transactionId: string, splitwiseExpenseId: string) => Promise<void>;
   deleteCombinedSplit: (transactionIds: string[], splitwiseExpenseId: string) => Promise<void>;
+  loadReview: () => Promise<void>;
+  resolveReview: (transactionIds: string[]) => Promise<void>;
 }
 
 export const useTransactionStore = create<TransactionState>((set, get) => ({
   transactions: [],
   isLoading: false,
+  review: [],
 
   load: async () => {
     set({ isLoading: true });
@@ -53,8 +60,26 @@ export const useTransactionStore = create<TransactionState>((set, get) => ({
         while (hasMore) {
           const res = await fetchTransactions(access_token, pageCursor);
           if (!isFirstSync) {
-            await upsertTransactions([...res.added, ...res.modified], activeVacationId);
-            await deleteTransactionsByPlaidIds(res.removed.map((r) => r.transaction_id));
+            const all = [...res.added, ...res.modified];
+            // 1. Rekey pending → posted BEFORE inserting anything, so the posted row
+            //    inherits status / vacation_id / split decision instead of arriving new.
+            const consumed = new Set<string>();
+            for (const tx of all) {
+              if (!tx.pending_transaction_id) continue;
+              const result = await rekeyTransaction(tx.pending_transaction_id, tx);
+              if (result !== 'not_found') consumed.add(tx.pending_transaction_id);
+            }
+            // 2. Upsert. Rekeyed rows already carry the posted id, so INSERT OR IGNORE
+            //    no-ops and the status-gated UPDATE leaves split rows alone.
+            await upsertTransactions(all, activeVacationId);
+            // 3. Delete removals, minus ids a rekey already consumed and minus ids that
+            //    reappear in this page's added/modified — some institutions reuse the
+            //    transaction id, and deleting there would drop the row we just kept.
+            const addedIds = new Set(all.map((t) => t.transaction_id));
+            const toRemove = res.removed
+              .map((r) => r.transaction_id)
+              .filter((rid) => !consumed.has(rid) && !addedIds.has(rid));
+            await markTransactionsReversed(toRemove);
             await usePlaidStore.getState().saveCursor(id, res.next_cursor);
           }
           pageCursor = res.next_cursor;
@@ -104,5 +129,15 @@ export const useTransactionStore = create<TransactionState>((set, get) => ({
     await deleteExpense(splitwiseExpenseId);
     await revertCombinedSplit(transactionIds);
     await get().load();
+  },
+
+  loadReview: async () => {
+    const items = await getReviewTransactions();
+    set({ review: items });
+  },
+
+  resolveReview: async (transactionIds) => {
+    await clearReview(transactionIds);
+    await get().loadReview();
   },
 }));

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -94,6 +94,10 @@ interface PlaidTransaction {
   transaction_id: string;
   amount: number;
   pending?: boolean;
+  // Set on the posted transaction when it replaces a pending one; points back
+  // at the pending transaction_id. Passed through untouched via the index
+  // signature below — declared here only for documentation.
+  pending_transaction_id?: string | null;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## The bug

Split a pending transaction, and when it posts, the split silently comes undone — the transaction reappears as unsplit while the Splitwise expense stays behind, unlinked from anything in the app.

**Root cause:** the app treats Plaid's `transaction_id` as stable across the pending → posted transition. It isn't. `/transactions/sync` reports the pending id in `removed` and the posted transaction in `added` under a **brand-new id**, linked only by `pending_transaction_id` — a field that appeared nowhere in the codebase (`grep` over `mobile/` and `workers/src` returned zero hits).

So on every transition, `refresh()` inserted the posted transaction as a fresh `status='new'` row and deleted the row holding the split decision. The Splitwise expense was never touched.

## The fix

Sync now **rekeys** the local row onto the posted id *before* upserting, so `status`, `vacation_id` and the split decision carry over instead of being recreated. Removals are then filtered to exclude rekey-consumed ids and ids that reappear in the same page — which also fixes institutions that reuse transaction ids, where the old code deleted the row it had just kept.

| Case | Behavior |
|---|---|
| Amount unchanged | Row never moves. Stays in History with split info intact. |
| Amount changed | Stays in History **and** surfaces in a new "Needs review" section on Transactions showing `was $42.10 → now $45.60`. Tapping opens the existing edit flow against the original Splitwise expense. |
| Reversal (pending charge never posts) | Row is kept and flagged instead of silently deleted, offering to delete the now-stranded expense. |

A free win: rekeying preserves `skipped` too, so a transaction dismissed while pending no longer comes back to ask again.

## Two related defects fixed along the way

**Inert `ON DELETE CASCADE` on native.** `split_decisions.transaction_id` declares `REFERENCES transactions(id) ON DELETE CASCADE`, but `PRAGMA foreign_keys = ON` is never issued and SQLite defaults it off — so deletes orphaned decision rows on native while `db.web.ts` deleted both. Native and web genuinely diverged.

Fixed with an explicit `DELETE`, **not** by enabling the pragma: `deleteVacation` only nulls `vacation_id` on `status='new'` rows, so turning foreign keys on would make it start failing for any vacation with split transactions.

**Rekeying onto an occupied id.** If Plaid inserts the posted transaction in one sync page and reports its `pending_transaction_id` in a later one, the target id is already taken. Now resolved instead of left to abort the sync: a `split` occupant is never clobbered (returns `'conflict'`, both rows untouched, no expense stranded); a `new`/`skipped` occupant is the duplicate being superseded and is dropped. This was *silent* on web — IndexedDB `put()` overwrites where SQLite aborts.

## Verification

```
npx tsc --noEmit   → exit 0
npm test           → 24 suites, 248 tests passing (was 240)
```

Built test-first. New coverage spans both DB backends for every rekey outcome, reversal handling, review-queue grouping, and the sync ordering — including that an id in both `added` and `removed` is not deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)