### PR TITLE
fix: pin bottom-sheet CTAs so they can't scroll off-screen

### DIFF
--- a/mobile/__tests__/app/vacation-new.test.tsx
+++ b/mobile/__tests__/app/vacation-new.test.tsx
@@ -1,0 +1,56 @@
+// mobile/__tests__/app/vacation-new.test.tsx
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: jest.fn(), replace: jest.fn() }),
+}));
+jest.mock('@/stores/vacationStore', () => ({ useVacationStore: jest.fn() }));
+jest.mock('@/lib/splitwise', () => ({ getGroups: jest.fn() }));
+jest.mock('@/components/ToastProvider', () => ({ useToast: () => ({ show: jest.fn() }) }));
+
+import { render, fireEvent, screen, waitFor, act } from '@testing-library/react-native';
+import NewVacationScreen from '@/app/vacation/new';
+import { useVacationStore } from '@/stores/vacationStore';
+import { getGroups } from '@/lib/splitwise';
+import { SplitwiseGroup } from '@/lib/types';
+
+const mockGetGroups = getGroups as jest.Mock;
+
+const groups: SplitwiseGroup[] = [
+  { id: '1', name: 'Hawaii Crew', member_ids: ['1', '2'], member_names: ['A', 'B'] },
+  { id: '2', name: 'Roommates', member_ids: ['1', '3'], member_names: ['A', 'C'] },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useVacationStore as unknown as jest.Mock).mockImplementation((sel) => sel({ create: jest.fn() }));
+  mockGetGroups.mockResolvedValue(groups);
+});
+
+test('the group dropdown is collapsed by default and reveals options on tap', async () => {
+  render(<NewVacationScreen />);
+  await waitFor(() => expect(screen.getByLabelText('Select Splitwise group')).toBeTruthy());
+
+  expect(screen.queryByLabelText('Hawaii Crew')).toBeNull();
+  expect(screen.queryByLabelText('Roommates')).toBeNull();
+
+  await act(async () => {
+    fireEvent.press(screen.getByLabelText('Select Splitwise group'));
+  });
+
+  expect(screen.getByLabelText('Hawaii Crew')).toBeTruthy();
+  expect(screen.getByLabelText('Roommates')).toBeTruthy();
+});
+
+test('selecting a group updates the trigger label and collapses the list', async () => {
+  render(<NewVacationScreen />);
+  await waitFor(() => expect(screen.getByLabelText('Select Splitwise group')).toBeTruthy());
+
+  await act(async () => {
+    fireEvent.press(screen.getByLabelText('Select Splitwise group'));
+  });
+  expect(screen.getByLabelText('None')).toBeTruthy();
+
+  fireEvent.press(screen.getByLabelText('Roommates'));
+
+  expect(screen.getByText('Roommates')).toBeTruthy();
+  expect(screen.queryByLabelText('Hawaii Crew')).toBeNull();
+});

--- a/mobile/__tests__/components/AddToVacationSheet.test.tsx
+++ b/mobile/__tests__/components/AddToVacationSheet.test.tsx
@@ -1,5 +1,36 @@
 // mobile/__tests__/components/AddToVacationSheet.test.tsx
-jest.mock('@gorhom/bottom-sheet', () => require('@gorhom/bottom-sheet/mock'));
+jest.mock('@gorhom/bottom-sheet', () => {
+  const React = require('react');
+  const actual = require('@gorhom/bottom-sheet/mock');
+
+  // The library's own test mock renders `children` only and silently drops
+  // `footerComponent`, so the confirm CTA (now rendered via `footerComponent`
+  // + `BottomSheetFooter`) would never appear in the tree. Extend the mock's
+  // BottomSheetModal to also render the footer, and stub BottomSheetFooter
+  // as a passthrough.
+  class BottomSheetModal extends actual.BottomSheetModal {
+    render() {
+      const content = super.render();
+      const Footer = this.props.footerComponent;
+      if (!Footer) return content;
+      return React.createElement(
+        React.Fragment,
+        null,
+        content,
+        React.createElement(Footer, { animatedFooterPosition: { value: 0 } })
+      );
+    }
+  }
+
+  return {
+    ...actual,
+    BottomSheetModal,
+    BottomSheetFooter: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock('@/lib/db');
 jest.mock('@expo/vector-icons', () => new Proxy({}, { get: () => () => null }));
 

--- a/mobile/__tests__/components/FriendPickerSheet.test.tsx
+++ b/mobile/__tests__/components/FriendPickerSheet.test.tsx
@@ -1,5 +1,36 @@
 // mobile/__tests__/components/FriendPickerSheet.test.tsx
-jest.mock('@gorhom/bottom-sheet', () => require('@gorhom/bottom-sheet/mock'));
+jest.mock('@gorhom/bottom-sheet', () => {
+  const React = require('react');
+  const actual = require('@gorhom/bottom-sheet/mock');
+
+  // The library's own test mock renders `children` only and silently drops
+  // `footerComponent`, so the CTA (now rendered via `footerComponent` +
+  // `BottomSheetFooter`) would never appear in the tree. Extend the mock's
+  // BottomSheetModal to also render the footer, and stub BottomSheetFooter
+  // as a passthrough.
+  class BottomSheetModal extends actual.BottomSheetModal {
+    render() {
+      const content = super.render();
+      const Footer = this.props.footerComponent;
+      if (!Footer) return content;
+      return React.createElement(
+        React.Fragment,
+        null,
+        content,
+        React.createElement(Footer, { animatedFooterPosition: { value: 0 } })
+      );
+    }
+  }
+
+  return {
+    ...actual,
+    BottomSheetModal,
+    BottomSheetFooter: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock('@/lib/db');
 // Keep SplitwiseAuthError real (the component uses `instanceof`); mock the calls.
 jest.mock('@/lib/splitwise', () => ({
@@ -106,12 +137,15 @@ test('saving an edit updates the Splitwise expense and the local decision', asyn
 test('the CTA is reusable after a successful save (submitting is reset)', async () => {
   renderEdit();
   await waitFor(() => expect(mockGetExpense).toHaveBeenCalled());
-  const cta = screen.getByLabelText('Add split to Splitwise');
 
-  fireEvent.press(cta);
+  fireEvent.press(screen.getByLabelText('Add split to Splitwise'));
   await waitFor(() => expect(mockUpdateExpense).toHaveBeenCalledTimes(1));
 
-  fireEvent.press(cta);
+  // Re-query rather than reuse the pre-press node: the CTA is rendered via
+  // `footerComponent`, which the (real) library instantiates as a component
+  // type, so a `submitting` flip — an intentional dep of the memoized
+  // renderer — remounts the footer subtree with a fresh instance.
+  fireEvent.press(screen.getByLabelText('Add split to Splitwise'));
   await waitFor(() => expect(mockUpdateExpense).toHaveBeenCalledTimes(2));
 });
 
@@ -243,6 +277,28 @@ test('single create passes the edited title as the description', async () => {
   expect(mockCommitCombined.mock.calls[0][0]).toEqual([
     expect.objectContaining({ transaction_id: 'tx1', description: 'Groceries' }),
   ]);
+});
+
+// Regression: the CTA lives in the sheet's pinned footer, which the library
+// renders as a component type — so `renderFooter` is memoized on a narrow dep
+// list to avoid remounting the footer subtree on every keystroke. Editing the
+// title AFTER selecting a friend leaves `ctaDisabled` unchanged, so the footer
+// is not recreated; the press handler must still see the current title rather
+// than the closure captured when the CTA last became enabled.
+test('create uses the title edited after the CTA became enabled', async () => {
+  render(
+    <FriendPickerSheet transaction={{ ...tx, status: 'new' }} openToken={1} onSuccess={jest.fn()} />
+  );
+  // Order matters: selecting first is what flips `ctaDisabled` and freezes the
+  // memoized footer. Reversing these two lines makes this test pass either way.
+  fireEvent.press(screen.getByLabelText('Sam'));
+  fireEvent.changeText(screen.getByLabelText('Split title'), 'Late edit');
+  fireEvent.press(screen.getByLabelText('Add split to Splitwise'));
+
+  await waitFor(() => expect(mockCreateExpense).toHaveBeenCalledTimes(1));
+  expect(mockCreateExpense).toHaveBeenCalledWith(
+    expect.objectContaining({ description: 'Late edit' })
+  );
 });
 
 // Regression: the sheet renders null until it has a transaction, so every hook

--- a/mobile/app/vacation/new.tsx
+++ b/mobile/app/vacation/new.tsx
@@ -22,6 +22,7 @@ export default function NewVacationScreen() {
   const [endDate, setEndDate] = useState('');
   const [groups, setGroups] = useState<SplitwiseGroup[]>([]);
   const [selectedGroup, setSelectedGroup] = useState<SplitwiseGroup | null>(null);
+  const [groupPickerOpen, setGroupPickerOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
@@ -104,22 +105,61 @@ export default function NewVacationScreen() {
         {groups.length > 0 && (
           <>
             <Text style={styles.label}>Splitwise group (optional)</Text>
-            {groups.map((g) => {
-              const isSelected = selectedGroup?.id === g.id;
-              return (
-                <Pressable
-                  key={g.id}
-                  style={[styles.groupRow, isSelected && styles.groupRowSelected]}
-                  onPress={() => setSelectedGroup(isSelected ? null : g)}
-                  accessibilityRole="checkbox"
-                  accessibilityState={{ checked: isSelected }}
-                  accessibilityLabel={g.name}
-                >
-                  <Text style={styles.groupName}>{g.name}</Text>
-                  {isSelected && <Ionicons name="checkmark-circle" size={18} color={Colors.primary} />}
-                </Pressable>
-              );
-            })}
+            <Pressable
+              style={styles.groupTrigger}
+              onPress={() => setGroupPickerOpen((open) => !open)}
+              accessibilityRole="button"
+              accessibilityLabel="Select Splitwise group"
+              accessibilityState={{ expanded: groupPickerOpen }}
+            >
+              <Text style={selectedGroup ? styles.groupTriggerText : styles.groupTriggerPlaceholder}>
+                {selectedGroup ? selectedGroup.name : 'None'}
+              </Text>
+              <Ionicons
+                name={groupPickerOpen ? 'chevron-up' : 'chevron-down'}
+                size={18}
+                color={Colors.textSecondary}
+              />
+            </Pressable>
+
+            {groupPickerOpen && (
+              <View style={styles.groupPanel}>
+                <ScrollView nestedScrollEnabled style={styles.groupPanelScroll}>
+                  <Pressable
+                    style={[styles.groupRow, !selectedGroup && styles.groupRowSelected]}
+                    onPress={() => {
+                      setSelectedGroup(null);
+                      setGroupPickerOpen(false);
+                    }}
+                    accessibilityRole="checkbox"
+                    accessibilityState={{ checked: !selectedGroup }}
+                    accessibilityLabel="None"
+                  >
+                    <Text style={styles.groupName}>None</Text>
+                    {!selectedGroup && <Ionicons name="checkmark-circle" size={18} color={Colors.primary} />}
+                  </Pressable>
+                  {groups.map((g) => {
+                    const isSelected = selectedGroup?.id === g.id;
+                    return (
+                      <Pressable
+                        key={g.id}
+                        style={[styles.groupRow, isSelected && styles.groupRowSelected]}
+                        onPress={() => {
+                          setSelectedGroup(isSelected ? null : g);
+                          setGroupPickerOpen(false);
+                        }}
+                        accessibilityRole="checkbox"
+                        accessibilityState={{ checked: isSelected }}
+                        accessibilityLabel={g.name}
+                      >
+                        <Text style={styles.groupName}>{g.name}</Text>
+                        {isSelected && <Ionicons name="checkmark-circle" size={18} color={Colors.primary} />}
+                      </Pressable>
+                    );
+                  })}
+                </ScrollView>
+              </View>
+            )}
           </>
         )}
       </ScrollView>
@@ -154,6 +194,18 @@ const styles = StyleSheet.create({
   dateRow: { flexDirection: 'row', gap: Spacing.md },
   dateInput: { flex: 1 },
   error: { fontSize: 12, color: Colors.error, marginTop: Spacing.sm },
+  groupTrigger: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    backgroundColor: Colors.surface, borderRadius: Radius.md, borderWidth: 1, borderColor: Colors.border,
+    paddingHorizontal: Spacing.md, paddingVertical: 12,
+  },
+  groupTriggerText: { fontSize: 15, color: Colors.textPrimary },
+  groupTriggerPlaceholder: { fontSize: 15, color: Colors.textTertiary },
+  groupPanel: {
+    marginTop: Spacing.sm, maxHeight: 240, borderRadius: Radius.md, borderWidth: 1, borderColor: Colors.border,
+    backgroundColor: Colors.surface, ...Shadow.sm,
+  },
+  groupPanelScroll: { padding: Spacing.sm },
   groupRow: {
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
     backgroundColor: Colors.surface, borderRadius: Radius.md, borderWidth: 1, borderColor: Colors.border,

--- a/mobile/components/AddToVacationSheet.tsx
+++ b/mobile/components/AddToVacationSheet.tsx
@@ -1,7 +1,13 @@
 // mobile/components/AddToVacationSheet.tsx
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { BottomSheetModal, BottomSheetView, BottomSheetFlatList } from '@gorhom/bottom-sheet';
+import {
+  BottomSheetModal,
+  BottomSheetFlatList,
+  BottomSheetFooter,
+  type BottomSheetFooterProps,
+} from '@gorhom/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { getNewTransactions, assignTransactionsToVacation } from '@/lib/db';
 import { useToast } from '@/components/ToastProvider';
@@ -17,6 +23,7 @@ interface Props {
 export const AddToVacationSheet = forwardRef<BottomSheetModal, Props>(
   ({ vacationId, openToken, onDone }, ref) => {
     const toast = useToast();
+    const insets = useSafeAreaInsets();
     const [candidates, setCandidates] = useState<Transaction[]>([]);
     const [selected, setSelected] = useState<Set<string>>(new Set());
     const [submitting, setSubmitting] = useState(false);
@@ -47,55 +54,26 @@ export const AddToVacationSheet = forwardRef<BottomSheetModal, Props>(
       }
     }
 
-    return (
-      <BottomSheetModal
-        ref={ref}
-        snapPoints={['70%']}
-        enableDynamicSizing={false}
-        enablePanDownToClose
-        handleIndicatorStyle={styles.indicator}
-        backgroundStyle={styles.sheetBg}
-      >
-        <BottomSheetView style={styles.container}>
-          <Text style={styles.title}>Add transactions</Text>
-          {candidates.length === 0 ? (
-            <Text style={styles.empty}>No unassigned transactions to add.</Text>
-          ) : (
-            <BottomSheetFlatList
-              data={candidates}
-              keyExtractor={(t) => t.id}
-              style={styles.list}
-              renderItem={({ item }) => {
-                const isSelected = selected.has(item.id);
-                const color = merchantColor(item.merchant_name);
-                return (
-                  <Pressable
-                    style={[styles.row, isSelected && styles.rowSelected]}
-                    onPress={() => toggle(item.id)}
-                    accessibilityRole="checkbox"
-                    accessibilityState={{ checked: isSelected }}
-                    accessibilityLabel={`Select ${item.merchant_name}`}
-                  >
-                    <View style={[styles.avatar, { backgroundColor: color + '18' }]}>
-                      <Text style={[styles.avatarText, { color }]}>{item.merchant_name[0].toUpperCase()}</Text>
-                    </View>
-                    <Text style={styles.name} numberOfLines={1}>{item.merchant_name}</Text>
-                    <Text style={styles.amount}>${item.amount.toFixed(2)}</Text>
-                    <View style={[styles.checkbox, isSelected && styles.checkboxSelected]}>
-                      {isSelected && <Ionicons name="checkmark" size={13} color={Colors.textInverse} />}
-                    </View>
-                  </Pressable>
-                );
-              }}
-            />
-          )}
+    // The sheet renders the footer as a component type, so a change to
+    // `renderFooter`'s identity remounts the footer subtree. Keep the deps to
+    // what actually affects rendering and route the press through a ref, so
+    // the handler never goes stale on `vacationId`/`onDone` (the parent
+    // passes `onDone` as an inline arrow — a new identity every render).
+    const confirmRef = useRef(confirm);
+    confirmRef.current = confirm;
+
+    const renderFooter = useCallback(
+      // The footer style is opaque so list rows scrolling under the pinned
+      // footer don't show through in the gaps beside the button.
+      (footerProps: BottomSheetFooterProps) => (
+        <BottomSheetFooter {...footerProps} bottomInset={insets.bottom} style={styles.footer}>
           <Pressable
             style={({ pressed }) => [
               styles.confirmBtn,
               (selected.size === 0 || submitting) && styles.confirmBtnDisabled,
               pressed && selected.size > 0 && styles.confirmBtnPressed,
             ]}
-            onPress={confirm}
+            onPress={() => confirmRef.current()}
             disabled={selected.size === 0 || submitting}
             accessibilityRole="button"
             accessibilityLabel="Add to vacation"
@@ -104,7 +82,52 @@ export const AddToVacationSheet = forwardRef<BottomSheetModal, Props>(
               Add {selected.size > 0 ? `(${selected.size})` : ''}
             </Text>
           </Pressable>
-        </BottomSheetView>
+        </BottomSheetFooter>
+      ),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [selected, submitting, insets.bottom]
+    );
+
+    return (
+      <BottomSheetModal
+        ref={ref}
+        snapPoints={['70%']}
+        enableDynamicSizing={false}
+        enablePanDownToClose
+        handleIndicatorStyle={styles.indicator}
+        backgroundStyle={styles.sheetBg}
+        footerComponent={renderFooter}
+      >
+        <BottomSheetFlatList
+          data={candidates}
+          keyExtractor={(t) => t.id}
+          style={styles.list}
+          contentContainerStyle={styles.listContent}
+          ListHeaderComponent={<Text style={styles.title}>Add transactions</Text>}
+          ListEmptyComponent={<Text style={styles.empty}>No unassigned transactions to add.</Text>}
+          renderItem={({ item }) => {
+            const isSelected = selected.has(item.id);
+            const color = merchantColor(item.merchant_name);
+            return (
+              <Pressable
+                style={[styles.row, isSelected && styles.rowSelected]}
+                onPress={() => toggle(item.id)}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: isSelected }}
+                accessibilityLabel={`Select ${item.merchant_name}`}
+              >
+                <View style={[styles.avatar, { backgroundColor: color + '18' }]}>
+                  <Text style={[styles.avatarText, { color }]}>{item.merchant_name[0].toUpperCase()}</Text>
+                </View>
+                <Text style={styles.name} numberOfLines={1}>{item.merchant_name}</Text>
+                <Text style={styles.amount}>${item.amount.toFixed(2)}</Text>
+                <View style={[styles.checkbox, isSelected && styles.checkboxSelected]}>
+                  {isSelected && <Ionicons name="checkmark" size={13} color={Colors.textInverse} />}
+                </View>
+              </Pressable>
+            );
+          }}
+        />
       </BottomSheetModal>
     );
   }
@@ -113,10 +136,10 @@ export const AddToVacationSheet = forwardRef<BottomSheetModal, Props>(
 const styles = StyleSheet.create({
   indicator: { backgroundColor: Colors.border, width: 36 },
   sheetBg: { backgroundColor: Colors.surface },
-  container: { flex: 1, paddingHorizontal: Spacing.xl, paddingTop: Spacing.sm },
   title: { fontSize: 17, fontWeight: '700', color: Colors.textPrimary, marginBottom: Spacing.md },
   empty: { fontSize: 14, color: Colors.textSecondary, textAlign: 'center', marginTop: Spacing.xxl },
   list: { flex: 1 },
+  listContent: { paddingHorizontal: Spacing.xl, paddingTop: Spacing.sm, paddingBottom: 90 },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -136,9 +159,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center', alignItems: 'center', backgroundColor: Colors.surface,
   },
   checkboxSelected: { backgroundColor: Colors.primary, borderColor: Colors.primary },
+  footer: { backgroundColor: Colors.surface },
   confirmBtn: {
     backgroundColor: Colors.primary, borderRadius: Radius.lg, paddingVertical: 16,
-    justifyContent: 'center', alignItems: 'center', marginTop: Spacing.md, marginBottom: Spacing.md, ...Shadow.sm,
+    justifyContent: 'center', alignItems: 'center',
+    marginHorizontal: Spacing.xl, marginTop: Spacing.md, marginBottom: Spacing.md, ...Shadow.sm,
   },
   confirmBtnDisabled: { backgroundColor: Colors.surfaceMuted },
   confirmBtnPressed: { backgroundColor: Colors.primaryDark },

--- a/mobile/components/FriendPickerSheet.tsx
+++ b/mobile/components/FriendPickerSheet.tsx
@@ -1,5 +1,5 @@
 // mobile/components/FriendPickerSheet.tsx
-import { forwardRef, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { forwardRef, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -9,10 +9,12 @@ import {
 } from 'react-native';
 import {
   BottomSheetModal,
-  BottomSheetView,
   BottomSheetTextInput,
   BottomSheetFlatList,
+  BottomSheetFooter,
+  type BottomSheetFooterProps,
 } from '@gorhom/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useFriendStore } from '@/stores/friendStore';
 import { useAuthStore } from '@/stores/authStore';
@@ -52,6 +54,7 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
     const user_id = useAuthStore((s) => s.user_id);
     const markSplit = useTransactionStore((s) => s.markSplit);
     const commitCombinedSplit = useTransactionStore((s) => s.commitCombinedSplit);
+    const insets = useSafeAreaInsets();
 
     const members = useMemo(
       () =>
@@ -149,12 +152,9 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       });
     }, []);
 
-    // Every hook must run before this bail-out, or the render that first
-    // supplies a transaction adds hooks the previous render didn't have and
-    // React throws "rendered more hooks than during the previous render" —
-    // which unmounts the whole tree (blank screen) on tapping Split.
-    if (members.length === 0) return null;
-
+    // Derived CTA state is computed here (before the bail-out below) because
+    // the footer's useCallback is a hook and needs it, and every hook must
+    // run unconditionally before an early return.
     const totalCents = Math.round(totalAmount * 100);
     const n = selected.size + 1;
     const equalShareCents = selected.size > 0 ? Math.floor(totalCents / n) : 0;
@@ -170,6 +170,59 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
     const ownerShareCents = totalCents - friendTotalCents;
     const isOverBudget = ownerShareCents < -1;
     const ctaDisabled = selected.size === 0 || submitting || isOverBudget || title.trim() === '';
+
+    // The footer is rendered by the sheet as a component type, so whenever
+    // `renderFooter`'s identity changes the whole footer subtree remounts.
+    // That forces a narrow dep list — which would otherwise leave the CTA
+    // holding a stale `handleAddToSplitwise` (stale title/customAmounts/
+    // splitMode) whenever those change without flipping `ctaDisabled`.
+    // Routing the press through a ref keeps the handler current without
+    // widening the deps.
+    const submitRef = useRef<() => void>(() => {});
+
+    const renderFooter = useCallback(
+      // The footer style is opaque so list rows scrolling under the pinned
+      // footer don't show through in the gaps beside the button.
+      (footerProps: BottomSheetFooterProps) => (
+        <BottomSheetFooter {...footerProps} bottomInset={insets.bottom} style={styles.footer}>
+          <Pressable
+            style={({ pressed }) => [
+              styles.addBtn,
+              ctaDisabled && styles.addBtnDisabled,
+              pressed && !ctaDisabled && styles.addBtnPressed,
+            ]}
+            onPress={() => submitRef.current()}
+            disabled={ctaDisabled}
+            accessibilityRole="button"
+            accessibilityLabel="Add split to Splitwise"
+          >
+            {submitting ? (
+              <ActivityIndicator color={Colors.textInverse} />
+            ) : (
+              <>
+                <Ionicons
+                  name="checkmark-circle-outline"
+                  size={18}
+                  color={ctaDisabled ? Colors.textTertiary : Colors.textInverse}
+                  style={{ marginRight: 6 }}
+                />
+                <Text style={[styles.addBtnText, ctaDisabled && styles.addBtnTextDisabled]}>
+                  {mode === 'edit' ? 'Save changes' : 'Add to Splitwise'}
+                </Text>
+              </>
+            )}
+          </Pressable>
+        </BottomSheetFooter>
+      ),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [ctaDisabled, submitting, mode, insets.bottom]
+    );
+
+    // Every hook must run before this bail-out, or the render that first
+    // supplies a transaction adds hooks the previous render didn't have and
+    // React throws "rendered more hooks than during the previous render" —
+    // which unmounts the whole tree (blank screen) on tapping Split.
+    if (members.length === 0) return null;
 
     function switchToCustom() {
       const baseShareCents = Math.floor(totalCents / n);
@@ -286,8 +339,144 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
       }
     }
 
+    // Keep the pinned footer's press handler pointing at this render's
+    // closure (see submitRef above).
+    submitRef.current = handleAddToSplitwise;
+
     const titleColor = merchantColor(title || '?');
     const titleInitial = (title || '?')[0].toUpperCase();
+
+    // Header content differs by mode but must be a single element (not an
+    // inline component) — see the ListHeaderComponent prop below.
+    const listHeader = (
+      <View>
+        {/* Title + total */}
+        <View style={styles.txSummary}>
+          <View style={[styles.txAvatar, { backgroundColor: titleColor + '18' }]}>
+            <Text style={[styles.txAvatarText, { color: titleColor }]}>{titleInitial}</Text>
+          </View>
+          <View style={styles.txInfo}>
+            <BottomSheetTextInput
+              style={styles.titleInput}
+              value={title}
+              onChangeText={setTitle}
+              placeholder="Split title"
+              placeholderTextColor={Colors.textTertiary}
+              accessibilityLabel="Split title"
+              returnKeyType="done"
+            />
+            <Text style={styles.txTotal}>${totalAmount.toFixed(2)}</Text>
+          </View>
+        </View>
+
+        {/* Equal / Custom segmented control */}
+        {selected.size > 0 && (
+          <View style={styles.segmented}>
+            <Pressable
+              style={[styles.segBtn, splitMode === 'equal' && styles.segBtnActive]}
+              onPress={() => setSplitMode('equal')}
+              accessibilityRole="button"
+              accessibilityState={{ selected: splitMode === 'equal' }}
+            >
+              <Text style={[styles.segText, splitMode === 'equal' && styles.segTextActive]}>
+                Equal
+              </Text>
+            </Pressable>
+            <Pressable
+              style={[styles.segBtn, splitMode === 'custom' && styles.segBtnActive]}
+              onPress={switchToCustom}
+              accessibilityRole="button"
+              accessibilityState={{ selected: splitMode === 'custom' }}
+            >
+              <Text style={[styles.segText, splitMode === 'custom' && styles.segTextActive]}>
+                Custom
+              </Text>
+            </Pressable>
+          </View>
+        )}
+
+        {splitMode === 'equal' ? (
+          <>
+            {/* Equal split preview */}
+            {selected.size > 0 && (
+              <View style={styles.splitPreview}>
+                <Ionicons
+                  name="people-outline"
+                  size={16}
+                  color={Colors.primary}
+                  style={{ marginRight: 6 }}
+                />
+                <Text style={styles.splitPreviewText}>
+                  ${(ownerShareCents / 100).toFixed(2)} each · {n} people
+                </Text>
+              </View>
+            )}
+
+            {/* Search */}
+            <View style={styles.searchRow}>
+              <Ionicons
+                name="search-outline"
+                size={16}
+                color={Colors.textTertiary}
+                style={styles.searchIcon}
+              />
+              <BottomSheetTextInput
+                style={styles.searchInput}
+                placeholder="Search friends…"
+                placeholderTextColor={Colors.textTertiary}
+                value={query}
+                onChangeText={setQuery}
+                autoCorrect={false}
+                clearButtonMode="while-editing"
+                returnKeyType="search"
+                accessibilityLabel="Search friends"
+              />
+            </View>
+
+            <Text style={styles.sectionLabel}>
+              {query !== '' && filtered.length === 0
+                ? `No results for "${query}"`
+                : 'Select friends to split with'}
+            </Text>
+          </>
+        ) : (
+          <>
+            {/* Owner share card */}
+            <View style={[styles.ownerCard, isOverBudget && styles.ownerCardError]}>
+              <View>
+                <Text style={[styles.ownerLabel, isOverBudget && styles.ownerLabelError]}>
+                  Your share
+                </Text>
+                {isOverBudget && (
+                  <Text style={styles.ownerHint}>Reduce friend amounts to balance</Text>
+                )}
+              </View>
+              <Text style={[styles.ownerAmount, isOverBudget && styles.ownerAmountError]}>
+                {isOverBudget ? '—' : `$${(ownerShareCents / 100).toFixed(2)}`}
+              </Text>
+            </View>
+
+            <Text style={styles.sectionLabel}>Custom amounts</Text>
+          </>
+        )}
+      </View>
+    );
+
+    // isLoading/empty replace the list body only in equal mode (custom mode's
+    // data is the already-selected friends, which is never empty in practice).
+    const listEmpty =
+      splitMode === 'equal' ? (
+        isLoading ? (
+          <ActivityIndicator color={Colors.primary} style={styles.spinner} />
+        ) : friends.length === 0 ? (
+          <View style={styles.emptyContainer}>
+            <Ionicons name="people-outline" size={32} color={Colors.textTertiary} />
+            <Text style={styles.emptyText}>No Splitwise friends found.</Text>
+          </View>
+        ) : null
+      ) : null;
+
+    const data = splitMode === 'equal' ? filtered : selectedFriends;
 
     return (
       <BottomSheetModal
@@ -299,186 +488,30 @@ export const FriendPickerSheet = forwardRef<BottomSheetModal, Props>(
         backgroundStyle={styles.sheetBg}
         keyboardBehavior="interactive"
         keyboardBlurBehavior="restore"
+        footerComponent={renderFooter}
       >
-        <BottomSheetView style={styles.container}>
-          {/* Title + total */}
-          <View style={styles.txSummary}>
-            <View style={[styles.txAvatar, { backgroundColor: titleColor + '18' }]}>
-              <Text style={[styles.txAvatarText, { color: titleColor }]}>{titleInitial}</Text>
-            </View>
-            <View style={styles.txInfo}>
-              <BottomSheetTextInput
-                style={styles.titleInput}
-                value={title}
-                onChangeText={setTitle}
-                placeholder="Split title"
-                placeholderTextColor={Colors.textTertiary}
-                accessibilityLabel="Split title"
-                returnKeyType="done"
-              />
-              <Text style={styles.txTotal}>${totalAmount.toFixed(2)}</Text>
-            </View>
-          </View>
-
-          {/* Equal / Custom segmented control */}
-          {selected.size > 0 && (
-            <View style={styles.segmented}>
-              <Pressable
-                style={[styles.segBtn, splitMode === 'equal' && styles.segBtnActive]}
-                onPress={() => setSplitMode('equal')}
-                accessibilityRole="button"
-                accessibilityState={{ selected: splitMode === 'equal' }}
-              >
-                <Text style={[styles.segText, splitMode === 'equal' && styles.segTextActive]}>
-                  Equal
-                </Text>
-              </Pressable>
-              <Pressable
-                style={[styles.segBtn, splitMode === 'custom' && styles.segBtnActive]}
-                onPress={switchToCustom}
-                accessibilityRole="button"
-                accessibilityState={{ selected: splitMode === 'custom' }}
-              >
-                <Text style={[styles.segText, splitMode === 'custom' && styles.segTextActive]}>
-                  Custom
-                </Text>
-              </Pressable>
-            </View>
-          )}
-
-          {splitMode === 'equal' ? (
-            <>
-              {/* Equal split preview */}
-              {selected.size > 0 && (
-                <View style={styles.splitPreview}>
-                  <Ionicons
-                    name="people-outline"
-                    size={16}
-                    color={Colors.primary}
-                    style={{ marginRight: 6 }}
-                  />
-                  <Text style={styles.splitPreviewText}>
-                    ${(ownerShareCents / 100).toFixed(2)} each · {n} people
-                  </Text>
-                </View>
-              )}
-
-              {/* Search */}
-              <View style={styles.searchRow}>
-                <Ionicons
-                  name="search-outline"
-                  size={16}
-                  color={Colors.textTertiary}
-                  style={styles.searchIcon}
-                />
-                <BottomSheetTextInput
-                  style={styles.searchInput}
-                  placeholder="Search friends…"
-                  placeholderTextColor={Colors.textTertiary}
-                  value={query}
-                  onChangeText={setQuery}
-                  autoCorrect={false}
-                  clearButtonMode="while-editing"
-                  returnKeyType="search"
-                  accessibilityLabel="Search friends"
-                />
-              </View>
-
-              <Text style={styles.sectionLabel}>
-                {query !== '' && filtered.length === 0
-                  ? `No results for "${query}"`
-                  : 'Select friends to split with'}
-              </Text>
-
-              {isLoading ? (
-                <ActivityIndicator color={Colors.primary} style={styles.spinner} />
-              ) : friends.length === 0 ? (
-                <View style={styles.emptyContainer}>
-                  <Ionicons name="people-outline" size={32} color={Colors.textTertiary} />
-                  <Text style={styles.emptyText}>No Splitwise friends found.</Text>
-                </View>
-              ) : (
-                <BottomSheetFlatList
-                  data={filtered}
-                  keyExtractor={(f) => f.id}
-                  style={styles.list}
-                  keyboardShouldPersistTaps="handled"
-                  renderItem={({ item }) => (
-                    <EqualRow
-                      friend={item}
-                      isSelected={selected.has(item.id)}
-                      onToggle={toggle}
-                    />
-                  )}
-                />
-              )}
-            </>
-          ) : (
-            <>
-              {/* Owner share card */}
-              <View style={[styles.ownerCard, isOverBudget && styles.ownerCardError]}>
-                <View>
-                  <Text style={[styles.ownerLabel, isOverBudget && styles.ownerLabelError]}>
-                    Your share
-                  </Text>
-                  {isOverBudget && (
-                    <Text style={styles.ownerHint}>Reduce friend amounts to balance</Text>
-                  )}
-                </View>
-                <Text style={[styles.ownerAmount, isOverBudget && styles.ownerAmountError]}>
-                  {isOverBudget ? '—' : `$${(ownerShareCents / 100).toFixed(2)}`}
-                </Text>
-              </View>
-
-              <Text style={styles.sectionLabel}>Custom amounts</Text>
-
-              <BottomSheetFlatList
-                data={selectedFriends}
-                keyExtractor={(f) => f.id}
-                style={styles.list}
-                keyboardShouldPersistTaps="handled"
-                renderItem={({ item }) => (
-                  <CustomRow
-                    friend={item}
-                    amount={customAmounts[item.id] ?? 0}
-                    onDecrease={() => adjustAmount(item.id, -STEP)}
-                    onIncrease={() => adjustAmount(item.id, STEP)}
-                    onCommit={(v) => commitAmount(item.id, v)}
-                  />
-                )}
-              />
-            </>
-          )}
-
-          {/* CTA */}
-          <Pressable
-            style={({ pressed }) => [
-              styles.addBtn,
-              ctaDisabled && styles.addBtnDisabled,
-              pressed && !ctaDisabled && styles.addBtnPressed,
-            ]}
-            onPress={handleAddToSplitwise}
-            disabled={ctaDisabled}
-            accessibilityRole="button"
-            accessibilityLabel="Add split to Splitwise"
-          >
-            {submitting ? (
-              <ActivityIndicator color={Colors.textInverse} />
+        <BottomSheetFlatList
+          data={data}
+          keyExtractor={(f) => f.id}
+          style={styles.list}
+          contentContainerStyle={styles.listContent}
+          keyboardShouldPersistTaps="handled"
+          ListHeaderComponent={listHeader}
+          ListEmptyComponent={listEmpty}
+          renderItem={({ item }) =>
+            splitMode === 'equal' ? (
+              <EqualRow friend={item} isSelected={selected.has(item.id)} onToggle={toggle} />
             ) : (
-              <>
-                <Ionicons
-                  name="checkmark-circle-outline"
-                  size={18}
-                  color={ctaDisabled ? Colors.textTertiary : Colors.textInverse}
-                  style={{ marginRight: 6 }}
-                />
-                <Text style={[styles.addBtnText, ctaDisabled && styles.addBtnTextDisabled]}>
-                  {mode === 'edit' ? 'Save changes' : 'Add to Splitwise'}
-                </Text>
-              </>
-            )}
-          </Pressable>
-        </BottomSheetView>
+              <CustomRow
+                friend={item}
+                amount={customAmounts[item.id] ?? 0}
+                onDecrease={() => adjustAmount(item.id, -STEP)}
+                onIncrease={() => adjustAmount(item.id, STEP)}
+                onCommit={(v) => commitAmount(item.id, v)}
+              />
+            )
+          }
+        />
       </BottomSheetModal>
     );
   }
@@ -600,7 +633,8 @@ function CustomRow({
 const styles = StyleSheet.create({
   indicator: { backgroundColor: Colors.border, width: 36 },
   sheetBg: { backgroundColor: Colors.surface },
-  container: { flex: 1, paddingHorizontal: Spacing.xl, paddingTop: Spacing.sm },
+  listContent: { paddingHorizontal: Spacing.xl, paddingTop: Spacing.sm, paddingBottom: 90 },
+  footer: { backgroundColor: Colors.surface },
 
   txSummary: {
     flexDirection: 'row',
@@ -803,6 +837,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
+    marginHorizontal: Spacing.xl,
     marginTop: Spacing.md,
     marginBottom: Spacing.md,
     minHeight: 52,


### PR DESCRIPTION
## The bug

The **Add** button in the vacation *Add transactions* sheet was unreachable — with more than a few candidate transactions the list ran past the bottom edge of the screen and the button was laid out below it. Reported with a screenshot showing rows running off the bottom and no button anywhere.

## Root cause

`@gorhom/bottom-sheet@5.2.14`'s `BottomSheetView` composes styles as `[callerStyle, styles.container]` — library last — where `styles.container` is:

```js
{ position: 'absolute', left: 0, top: 0, right: 0 }
```

So our `container: { flex: 1 }` was **silently overridden**. With `position: absolute` and no `bottom`/`height`, the content view's height becomes its intrinsic content height rather than the sheet's snap point. The inner `BottomSheetFlatList` got no height bound, rendered at full content height, and the trailing CTA landed below the visible sheet area — no error, no visual clue.

## The fix

Both sheets now make the scrollable a **direct child** of `BottomSheetModal` (`bottomSheetScrollable`'s own style is `{ flex: 1, overflow: 'visible' }`, which *does* fill the sheet) and pin the CTA with the `footerComponent` prop + `BottomSheetFooter`, which is positioned independently of content height.

- **`AddToVacationSheet`** — title → `ListHeaderComponent`, empty state → `ListEmptyComponent`, CTA → footer.
- **`FriendPickerSheet`** — had the identical latent bug; it only *looked* fine because short friend lists kept its CTA on screen. One `BottomSheetFlatList` now drives both split modes, with the header block passed as an **element** (not a component) so the title/search inputs don't remount and lose focus on every keystroke.

### Stale-closure guard

The sheet renders `footerComponent` as a component *type*, so any change to the render function's identity remounts the footer subtree. That forces a narrow dep list — which would otherwise leave the CTA holding a stale handler. Concretely: **editing the split title after the CTA became enabled submitted the old title**, because `ctaDisabled` didn't flip and the memoized footer wasn't recreated. Both footers now memoize on render-affecting state only and route the press through a ref. Covered by a new regression test (verified failing without the fix).

## Also in here

The New-vacation screen rendered every Splitwise group as a full-width row inline in the form. Replaced with a collapsed dropdown: a field-styled trigger showing the selection (or `None`), expanding into a height-capped scrollable panel with an explicit "None" row for clearing. `handleSave`'s payload is unchanged.

## Verification

```
$ npx tsc --noEmit
(clean)

$ npx jest --watchAll=false
Test Suites: 25 passed, 25 total
Tests:       251 passed, 251 total
```

New coverage: the title-staleness regression, and two tests for the group dropdown (reveal-on-tap, select-updates-label).

## Reviewer note

`BottomSheetView` remains safe for short, dynamically-sized content — `HistoryActionSheet` still uses it correctly. The trap is specifically `BottomSheetView` + `flex: 1` + a scrollable + a trailing button. Worth knowing before adding the next sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4yNBGWGvDeJhEj2V4N1j1