### PR TITLE
fix: stop text and controls overflowing on mobile widths

### DIFF
--- a/mobile/app/(auth)/bank-connect.tsx
+++ b/mobile/app/(auth)/bank-connect.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, StatusBar, StyleSheet, Text, View } from 'react-native';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { usePlaidStore } from '@/stores/plaidStore';
 import { showDialog } from '@/lib/dialog';
 import { getLinkToken, WorkerError } from '@/lib/worker';
@@ -14,6 +15,7 @@ export default function BankConnectScreen() {
   const linkBank = usePlaidStore((s) => s.linkBank);
   const router = useRouter();
   const canGoBack = router.canGoBack();
+  const insets = useSafeAreaInsets();
 
   useEffect(() => {
     return () => {
@@ -66,7 +68,7 @@ export default function BankConnectScreen() {
 
       {canGoBack && (
         <Pressable
-          style={styles.backBtn}
+          style={[styles.backBtn, { top: insets.top + Spacing.sm }]}
           onPress={() => router.back()}
           accessibilityRole="button"
           accessibilityLabel="Go back"
@@ -141,7 +143,6 @@ const styles = StyleSheet.create({
 
   backBtn: {
     position: 'absolute',
-    top: 56,
     left: Spacing.lg,
     zIndex: 10,
     width: 40,

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Tabs } from 'expo-router';
 import { useEffect } from 'react';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTransactionStore } from '@/stores/transactionStore';
 import { useFriendStore } from '@/stores/friendStore';
 import { useVacationStore } from '@/stores/vacationStore';
@@ -11,6 +12,7 @@ export default function TabsLayout() {
   const count = useTransactionStore((s) => s.transactions.length);
   const loadFriends = useFriendStore((s) => s.load);
   const reconcileVacations = useVacationStore((s) => s.reconcile);
+  const insets = useSafeAreaInsets();
 
   useEffect(() => {
     loadFriends();
@@ -29,8 +31,10 @@ export default function TabsLayout() {
           borderTopColor: '#E2E8F0',
           borderTopWidth: 1,
           paddingTop: 6,
-          paddingBottom: 4,
-          height: 60,
+          // Account for the home-indicator inset so labels aren't rendered
+          // inside the 34pt home-indicator strip on iPhone X and later.
+          paddingBottom: insets.bottom + 4,
+          height: 60 + insets.bottom,
         },
         tabBarLabelStyle: {
           fontSize: 11,

--- a/mobile/app/(tabs)/history.tsx
+++ b/mobile/app/(tabs)/history.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FlatList, Pressable, StatusBar, StyleSheet, Text, View } from 'react-native';
-import Constants from 'expo-constants';
 import { useFocusEffect } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { showDialog } from '@/lib/dialog';
@@ -31,6 +31,7 @@ function asTransaction(item: HistoryItem): Transaction {
 }
 
 export default function HistoryScreen() {
+  const insets = useSafeAreaInsets();
   const [rows, setRows] = useState<HistoryItem[]>([]);
   const [selected, setSelected] = useState<HistoryItem | null>(null);
   const [editDecision, setEditDecision] = useState<SplitDecision | null>(null);
@@ -159,7 +160,7 @@ export default function HistoryScreen() {
   }
 
   return (
-    <View style={[styles.root, { paddingTop: Constants.statusBarHeight }]}>
+    <View style={[styles.root, { paddingTop: insets.top }]}>
       <StatusBar barStyle="dark-content" backgroundColor={Colors.bg} />
       <View style={styles.header}>
         <Text style={styles.headerTitle}>History</Text>
@@ -241,7 +242,7 @@ function HistoryRow({ item, onPress }: { item: HistoryItem; onPress: () => void 
         {isSplit ? (
           <View style={styles.splitBadge}>
             <Ionicons name="people-outline" size={11} color={Colors.success} style={{ marginRight: 3 }} />
-            <Text style={styles.splitText}>
+            <Text style={styles.splitText} numberOfLines={1}>
               {item.split!.friend_names.join(', ')} · ${item.split!.amount_each.toFixed(2)} each
             </Text>
           </View>

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, Pressable, RefreshControl, StatusBar, StyleSheet, Text, View } from 'react-native';
-import Constants from 'expo-constants';
 import NetInfo from '@react-native-community/netinfo';
 import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useTransactionStore } from '@/stores/transactionStore';
 import { usePlaidStore } from '@/stores/plaidStore';
@@ -17,6 +17,9 @@ import { getSplitDecision, getTransactionsByIds, deleteTransactionsByPlaidIds } 
 import { Transaction, SplitDecision, ReviewItem } from '@/lib/types';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { Colors, Spacing, Radius, Shadow, merchantColor } from '@/lib/theme';
+
+// Clears the absolute-positioned selectBar so it doesn't cover the last row.
+const SELECT_BAR_CLEARANCE = 88;
 
 // Adapt a review item back to a Transaction for the picker's single-edit
 // flow. amount/currency/date come from the item (already the posted values
@@ -37,7 +40,7 @@ function reviewItemAsTransaction(item: ReviewItem): Transaction {
 
 export default function NewTransactionsScreen() {
   const router = useRouter();
-  const topInset = Constants.statusBarHeight;
+  const topInset = useSafeAreaInsets().top;
   const {
     transactions, isLoading, review, load, refresh, skip, loadReview, resolveReview,
     deleteSplit, deleteCombinedSplit,
@@ -240,7 +243,7 @@ export default function NewTransactionsScreen() {
         <FlatList
           data={transactions}
           keyExtractor={(t) => t.id}
-          contentContainerStyle={styles.list}
+          contentContainerStyle={[styles.list, selectMode && styles.listWithSelectBar]}
           extraData={listExtraData}
           refreshControl={
             <RefreshControl
@@ -391,7 +394,9 @@ function ReviewRow({ item, onPress }: { item: ReviewItem; onPress: () => void })
         {item.split.friend_names.length > 0 && (
           <View style={styles.reviewSplitBadge}>
             <Ionicons name="people-outline" size={11} color={Colors.textSecondary} style={{ marginRight: 3 }} />
-            <Text style={styles.reviewSplitText}>{item.split.friend_names.join(', ')}</Text>
+            <Text style={styles.reviewSplitText} numberOfLines={1}>
+              {item.split.friend_names.join(', ')}
+            </Text>
           </View>
         )}
       </View>
@@ -440,6 +445,7 @@ const styles = StyleSheet.create({
   },
 
   list: { padding: Spacing.lg, gap: 10 },
+  listWithSelectBar: { paddingBottom: SELECT_BAR_CLEARANCE },
 
   reviewSection: {
     marginBottom: Spacing.sm,
@@ -474,6 +480,7 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   reviewSplitText: {
+    flex: 1,
     fontSize: 12,
     color: Colors.textSecondary,
     fontWeight: '500',

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -1,6 +1,6 @@
 import { Image, Pressable, ScrollView, StatusBar, StyleSheet, Text, View } from 'react-native';
-import Constants from 'expo-constants';
 import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { showDialog } from '@/lib/dialog';
 import { useAuthStore } from '@/stores/authStore';
@@ -11,6 +11,7 @@ export default function SettingsScreen() {
   const { display_name, avatar_url, signOut } = useAuthStore();
   const { accounts, isLinked, disconnect } = usePlaidStore();
   const router = useRouter();
+  const insets = useSafeAreaInsets();
 
   function confirmSignOut() {
     showDialog(
@@ -57,7 +58,7 @@ export default function SettingsScreen() {
 
   return (
     <ScrollView
-      style={[styles.root, { paddingTop: Constants.statusBarHeight }]}
+      style={[styles.root, { paddingTop: insets.top }]}
       contentContainerStyle={styles.scrollContent}
     >
       <StatusBar barStyle="dark-content" backgroundColor={Colors.bg} />
@@ -76,7 +77,7 @@ export default function SettingsScreen() {
           </View>
         )}
         <View style={styles.profileInfo}>
-          <Text style={styles.profileName}>{display_name ?? 'Unknown'}</Text>
+          <Text style={styles.profileName} numberOfLines={1}>{display_name ?? 'Unknown'}</Text>
           <Text style={styles.profileSub}>Splitwise account</Text>
         </View>
         <View style={styles.splitwiseBadge}>
@@ -98,7 +99,7 @@ export default function SettingsScreen() {
                     <Ionicons name="business-outline" size={18} color={Colors.primary} />
                   </View>
                   <View style={styles.settingContent}>
-                    <Text style={styles.settingTitle}>{acct.institution_name}</Text>
+                    <Text style={styles.settingTitle} numberOfLines={1}>{acct.institution_name}</Text>
                     <Text style={styles.settingDesc}>Synced via Plaid</Text>
                   </View>
                   <Pressable

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -4,6 +4,7 @@ import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { Slot, SplashScreen } from 'expo-router';
 import { useEffect } from 'react';
 import { Platform, StyleSheet } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ToastProvider } from '@/components/ToastProvider';
 import { useAuthStore } from '@/stores/authStore';
 import { usePlaidStore } from '@/stores/plaidStore';
@@ -44,11 +45,17 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={styles.flex}>
-      <ToastProvider>
-        <BottomSheetModalProvider>
-          <Slot />
-        </BottomSheetModalProvider>
-      </ToastProvider>
+      {/* FriendPickerSheet and AddToVacationSheet call useSafeAreaInsets and
+          currently only resolve via the navigator's implicit
+          SafeAreaProviderCompat; an explicit root provider makes insets
+          reliable everywhere. */}
+      <SafeAreaProvider>
+        <ToastProvider>
+          <BottomSheetModalProvider>
+            <Slot />
+          </BottomSheetModalProvider>
+        </ToastProvider>
+      </SafeAreaProvider>
     </GestureHandlerRootView>
   );
 }

--- a/mobile/app/vacation/[id].tsx
+++ b/mobile/app/vacation/[id].tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { FlatList, Pressable, StatusBar, StyleSheet, Text, View } from 'react-native';
 import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { showDialog } from '@/lib/dialog';
 import { getVacationPendingTransactions, getVacationHistory, removeTransactionFromVacation } from '@/lib/db';
@@ -15,10 +16,13 @@ import { useToast } from '@/components/ToastProvider';
 import { HistoryItem, Transaction } from '@/lib/types';
 import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
 
+const SELECT_BAR_CONTENT_HEIGHT = 88;
+
 export default function VacationDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const toast = useToast();
+  const insets = useSafeAreaInsets();
   const vacations = useVacationStore((s) => s.vacations);
   const loadVacations = useVacationStore((s) => s.load);
   const startVacation = useVacationStore((s) => s.startVacation);
@@ -173,7 +177,7 @@ export default function VacationDetailScreen() {
   return (
     <View style={styles.root}>
       <StatusBar barStyle="dark-content" backgroundColor={Colors.bg} />
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: insets.top + Spacing.sm }]}>
         <Pressable onPress={() => router.back()} accessibilityRole="button" accessibilityLabel="Go back">
           <Ionicons name="chevron-back" size={24} color={Colors.textPrimary} />
         </Pressable>
@@ -202,7 +206,7 @@ export default function VacationDetailScreen() {
         {vacation.splitwise_group_name && (
           <View style={styles.groupChip}>
             <Ionicons name="people-outline" size={12} color={Colors.primary} />
-            <Text style={styles.groupChipText}>{vacation.splitwise_group_name}</Text>
+            <Text style={styles.groupChipText} numberOfLines={1}>{vacation.splitwise_group_name}</Text>
           </View>
         )}
       </View>
@@ -231,7 +235,7 @@ export default function VacationDetailScreen() {
       <FlatList
         data={pending}
         keyExtractor={(t) => t.id}
-        contentContainerStyle={styles.list}
+        contentContainerStyle={[styles.list, selectMode && { paddingBottom: SELECT_BAR_CONTENT_HEIGHT + insets.bottom }]}
         ListHeaderComponent={
           pending.length > 0 ? (
             <View style={styles.sectionHeaderRow}>
@@ -272,7 +276,7 @@ export default function VacationDetailScreen() {
       />
 
       {selectMode && (
-        <View style={styles.selectBar}>
+        <View style={[styles.selectBar, { paddingBottom: Spacing.lg + insets.bottom }]}>
           <Pressable
             style={styles.selectCancel}
             onPress={() => { setSelectMode(false); setSelectedIds(new Set()); }}
@@ -322,7 +326,7 @@ function HistoryRecapRow({ item }: { item: HistoryItem }) {
       <View style={styles.recapInfo}>
         <Text style={styles.recapName} numberOfLines={1}>{item.merchant_name}</Text>
         {item.split && (
-          <Text style={styles.recapSplit}>
+          <Text style={styles.recapSplit} numberOfLines={1}>
             {item.split.friend_names.join(', ')} · ${item.split.amount_each.toFixed(2)} each
           </Text>
         )}
@@ -337,7 +341,7 @@ const styles = StyleSheet.create({
   notFound: { marginTop: 100, textAlign: 'center', color: Colors.textSecondary },
   header: {
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-    paddingHorizontal: Spacing.lg, paddingTop: 56, paddingBottom: Spacing.sm,
+    paddingHorizontal: Spacing.lg, paddingBottom: Spacing.sm,
   },
   headerTitle: { flex: 1, fontSize: 17, fontWeight: '700', color: Colors.textPrimary, marginHorizontal: Spacing.md, textAlign: 'center' },
   headerActions: { flexDirection: 'row', alignItems: 'center', gap: Spacing.md },
@@ -347,8 +351,10 @@ const styles = StyleSheet.create({
   statusText: { fontSize: 11, fontWeight: '600', color: Colors.textSecondary },
   statusTextActive: { color: Colors.success },
   dates: { fontSize: 12, color: Colors.textTertiary },
-  groupChip: { flexDirection: 'row', alignItems: 'center', gap: 4, backgroundColor: Colors.primaryMuted, borderRadius: Radius.full, paddingHorizontal: 10, paddingVertical: 4 },
-  groupChipText: { fontSize: 11, fontWeight: '600', color: Colors.primary },
+  // The chip must be allowed to shrink, or a long group name grows it past the
+  // screen edge; numberOfLines can only ellipsize once the width is bounded.
+  groupChip: { flexDirection: 'row', alignItems: 'center', gap: 4, backgroundColor: Colors.primaryMuted, borderRadius: Radius.full, paddingHorizontal: 10, paddingVertical: 4, flexShrink: 1, maxWidth: '100%' },
+  groupChipText: { fontSize: 11, fontWeight: '600', color: Colors.primary, flexShrink: 1, minWidth: 0 },
   lifecycleRow: { flexDirection: 'row', gap: Spacing.sm, paddingHorizontal: Spacing.lg, marginBottom: Spacing.md },
   lifecycleBtn: { backgroundColor: Colors.primary, borderRadius: Radius.md, paddingVertical: 10, paddingHorizontal: Spacing.lg },
   lifecycleBtnText: { color: Colors.textInverse, fontSize: 13, fontWeight: '700' },

--- a/mobile/app/vacation/index.tsx
+++ b/mobile/app/vacation/index.tsx
@@ -2,6 +2,7 @@
 import { useCallback } from 'react';
 import { FlatList, Pressable, StatusBar, StyleSheet, Text, View } from 'react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useVacationStore } from '@/stores/vacationStore';
 import { Vacation } from '@/lib/types';
@@ -11,6 +12,7 @@ export default function VacationListScreen() {
   const router = useRouter();
   const vacations = useVacationStore((s) => s.vacations);
   const load = useVacationStore((s) => s.load);
+  const insets = useSafeAreaInsets();
 
   useFocusEffect(
     useCallback(() => {
@@ -24,7 +26,7 @@ export default function VacationListScreen() {
   return (
     <View style={styles.root}>
       <StatusBar barStyle="dark-content" backgroundColor={Colors.bg} />
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: insets.top + Spacing.sm }]}>
         <Pressable onPress={() => router.back()} accessibilityRole="button" accessibilityLabel="Go back">
           <Ionicons name="chevron-back" size={24} color={Colors.textPrimary} />
         </Pressable>
@@ -70,8 +72,8 @@ function VacationRow({ vacation, onPress }: { vacation: Vacation; onPress: () =>
       accessibilityLabel={`Open ${vacation.name} vacation`}
     >
       <View style={styles.info}>
-        <Text style={styles.name}>{vacation.name}</Text>
-        {dates && <Text style={styles.dates}>{dates}</Text>}
+        <Text style={styles.name} numberOfLines={1}>{vacation.name}</Text>
+        {dates && <Text style={styles.dates} numberOfLines={1}>{dates}</Text>}
       </View>
       <View style={[styles.statusPill, vacation.status === 'active' && styles.statusPillActive]}>
         <Text style={[styles.statusText, vacation.status === 'active' && styles.statusTextActive]}>{statusLabel}</Text>
@@ -84,7 +86,7 @@ const styles = StyleSheet.create({
   root: { flex: 1, backgroundColor: Colors.bg },
   header: {
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-    paddingHorizontal: Spacing.lg, paddingTop: 56, paddingBottom: Spacing.md,
+    paddingHorizontal: Spacing.lg, paddingBottom: Spacing.md,
   },
   headerTitle: { fontSize: 17, fontWeight: '700', color: Colors.textPrimary },
   list: { padding: Spacing.lg, gap: 8 },

--- a/mobile/app/vacation/new.tsx
+++ b/mobile/app/vacation/new.tsx
@@ -1,8 +1,9 @@
 // mobile/app/vacation/new.tsx
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, Pressable, ScrollView, StatusBar, StyleSheet, Text, TextInput, View } from 'react-native';
+import { ActivityIndicator, KeyboardAvoidingView, Platform, Pressable, ScrollView, StatusBar, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useVacationStore } from '@/stores/vacationStore';
 import { getGroups } from '@/lib/splitwise';
 import { VacationConflictError } from '@/lib/vacationErrors';
@@ -16,6 +17,7 @@ export default function NewVacationScreen() {
   const router = useRouter();
   const toast = useToast();
   const create = useVacationStore((s) => s.create);
+  const insets = useSafeAreaInsets();
 
   const [name, setName] = useState('');
   const [startDate, setStartDate] = useState('');
@@ -61,7 +63,7 @@ export default function NewVacationScreen() {
   return (
     <View style={styles.root}>
       <StatusBar barStyle="dark-content" backgroundColor={Colors.bg} />
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: insets.top + Spacing.sm }]}>
         <Pressable onPress={() => router.back()} accessibilityRole="button" accessibilityLabel="Go back">
           <Ionicons name="chevron-back" size={24} color={Colors.textPrimary} />
         </Pressable>
@@ -69,110 +71,125 @@ export default function NewVacationScreen() {
         <View style={{ width: 24 }} />
       </View>
 
-      <ScrollView contentContainerStyle={styles.body}>
-        <Text style={styles.label}>Name</Text>
-        <TextInput
-          style={styles.input}
-          value={name}
-          onChangeText={setName}
-          placeholder="Hawaii trip"
-          placeholderTextColor={Colors.textTertiary}
-          accessibilityLabel="Vacation name"
-        />
-
-        <Text style={styles.label}>Dates (optional)</Text>
-        <Text style={styles.hint}>If set, the vacation starts and ends automatically on these dates.</Text>
-        <View style={styles.dateRow}>
-          <TextInput
-            style={[styles.input, styles.dateInput]}
-            value={startDate}
-            onChangeText={setStartDate}
-            placeholder="YYYY-MM-DD"
-            placeholderTextColor={Colors.textTertiary}
-            accessibilityLabel="Start date"
-          />
-          <TextInput
-            style={[styles.input, styles.dateInput]}
-            value={endDate}
-            onChangeText={setEndDate}
-            placeholder="YYYY-MM-DD"
-            placeholderTextColor={Colors.textTertiary}
-            accessibilityLabel="End date"
-          />
-        </View>
-        {!datesValid && <Text style={styles.error}>Enter both dates as YYYY-MM-DD, end on or after start.</Text>}
-
-        {groups.length > 0 && (
-          <>
-            <Text style={styles.label}>Splitwise group (optional)</Text>
-            <Pressable
-              style={styles.groupTrigger}
-              onPress={() => setGroupPickerOpen((open) => !open)}
-              accessibilityRole="button"
-              accessibilityLabel="Select Splitwise group"
-              accessibilityState={{ expanded: groupPickerOpen }}
-            >
-              <Text style={selectedGroup ? styles.groupTriggerText : styles.groupTriggerPlaceholder}>
-                {selectedGroup ? selectedGroup.name : 'None'}
-              </Text>
-              <Ionicons
-                name={groupPickerOpen ? 'chevron-up' : 'chevron-down'}
-                size={18}
-                color={Colors.textSecondary}
-              />
-            </Pressable>
-
-            {groupPickerOpen && (
-              <View style={styles.groupPanel}>
-                <ScrollView nestedScrollEnabled style={styles.groupPanelScroll}>
-                  <Pressable
-                    style={[styles.groupRow, !selectedGroup && styles.groupRowSelected]}
-                    onPress={() => {
-                      setSelectedGroup(null);
-                      setGroupPickerOpen(false);
-                    }}
-                    accessibilityRole="checkbox"
-                    accessibilityState={{ checked: !selectedGroup }}
-                    accessibilityLabel="None"
-                  >
-                    <Text style={styles.groupName}>None</Text>
-                    {!selectedGroup && <Ionicons name="checkmark-circle" size={18} color={Colors.primary} />}
-                  </Pressable>
-                  {groups.map((g) => {
-                    const isSelected = selectedGroup?.id === g.id;
-                    return (
-                      <Pressable
-                        key={g.id}
-                        style={[styles.groupRow, isSelected && styles.groupRowSelected]}
-                        onPress={() => {
-                          setSelectedGroup(isSelected ? null : g);
-                          setGroupPickerOpen(false);
-                        }}
-                        accessibilityRole="checkbox"
-                        accessibilityState={{ checked: isSelected }}
-                        accessibilityLabel={g.name}
-                      >
-                        <Text style={styles.groupName}>{g.name}</Text>
-                        {isSelected && <Ionicons name="checkmark-circle" size={18} color={Colors.primary} />}
-                      </Pressable>
-                    );
-                  })}
-                </ScrollView>
-              </View>
-            )}
-          </>
-        )}
-      </ScrollView>
-
-      <Pressable
-        style={({ pressed }) => [styles.saveBtn, !canSave && styles.saveBtnDisabled, pressed && canSave && styles.saveBtnPressed]}
-        onPress={handleSave}
-        disabled={!canSave}
-        accessibilityRole="button"
-        accessibilityLabel="Save vacation"
+      <KeyboardAvoidingView
+        style={styles.keyboardAvoider}
+        behavior={Platform.select({ ios: 'padding', android: undefined })}
       >
-        {submitting ? <ActivityIndicator color={Colors.textInverse} /> : <Text style={styles.saveText}>Create vacation</Text>}
-      </Pressable>
+        <ScrollView contentContainerStyle={styles.body}>
+          <Text style={styles.label}>Name</Text>
+          <TextInput
+            style={styles.input}
+            value={name}
+            onChangeText={setName}
+            placeholder="Hawaii trip"
+            placeholderTextColor={Colors.textTertiary}
+            accessibilityLabel="Vacation name"
+          />
+
+          <Text style={styles.label}>Dates (optional)</Text>
+          <Text style={styles.hint}>If set, the vacation starts and ends automatically on these dates.</Text>
+          <View style={styles.dateRow}>
+            <TextInput
+              style={[styles.input, styles.dateInput]}
+              value={startDate}
+              onChangeText={setStartDate}
+              placeholder="YYYY-MM-DD"
+              placeholderTextColor={Colors.textTertiary}
+              accessibilityLabel="Start date"
+            />
+            <TextInput
+              style={[styles.input, styles.dateInput]}
+              value={endDate}
+              onChangeText={setEndDate}
+              placeholder="YYYY-MM-DD"
+              placeholderTextColor={Colors.textTertiary}
+              accessibilityLabel="End date"
+            />
+          </View>
+          {!datesValid && <Text style={styles.error}>Enter both dates as YYYY-MM-DD, end on or after start.</Text>}
+
+          {groups.length > 0 && (
+            <>
+              <Text style={styles.label}>Splitwise group (optional)</Text>
+              <Pressable
+                style={styles.groupTrigger}
+                onPress={() => setGroupPickerOpen((open) => !open)}
+                accessibilityRole="button"
+                accessibilityLabel="Select Splitwise group"
+                accessibilityState={{ expanded: groupPickerOpen }}
+              >
+                <Text
+                  style={selectedGroup ? styles.groupTriggerText : styles.groupTriggerPlaceholder}
+                  numberOfLines={1}
+                >
+                  {selectedGroup ? selectedGroup.name : 'None'}
+                </Text>
+                <Ionicons
+                  name={groupPickerOpen ? 'chevron-up' : 'chevron-down'}
+                  size={18}
+                  color={Colors.textSecondary}
+                />
+              </Pressable>
+
+              {groupPickerOpen && (
+                <View style={styles.groupPanel}>
+                  <ScrollView nestedScrollEnabled style={styles.groupPanelScroll}>
+                    <Pressable
+                      style={[styles.groupRow, !selectedGroup && styles.groupRowSelected]}
+                      onPress={() => {
+                        setSelectedGroup(null);
+                        setGroupPickerOpen(false);
+                      }}
+                      accessibilityRole="checkbox"
+                      accessibilityState={{ checked: !selectedGroup }}
+                      accessibilityLabel="None"
+                    >
+                      <Text style={styles.groupName} numberOfLines={1}>None</Text>
+                      {!selectedGroup && <Ionicons name="checkmark-circle" size={18} color={Colors.primary} />}
+                    </Pressable>
+                    {groups.map((g) => {
+                      const isSelected = selectedGroup?.id === g.id;
+                      return (
+                        <Pressable
+                          key={g.id}
+                          style={[styles.groupRow, isSelected && styles.groupRowSelected]}
+                          onPress={() => {
+                            setSelectedGroup(isSelected ? null : g);
+                            setGroupPickerOpen(false);
+                          }}
+                          accessibilityRole="checkbox"
+                          accessibilityState={{ checked: isSelected }}
+                          accessibilityLabel={g.name}
+                        >
+                          <Text style={styles.groupName} numberOfLines={1}>{g.name}</Text>
+                          {isSelected && <Ionicons name="checkmark-circle" size={18} color={Colors.primary} />}
+                        </Pressable>
+                      );
+                    })}
+                  </ScrollView>
+                </View>
+              )}
+            </>
+          )}
+        </ScrollView>
+
+        <Pressable
+          style={({ pressed }) => [
+            styles.saveBtn,
+            // Clear the home indicator without doubling the margin on devices
+            // that don't have one.
+            { marginBottom: Math.max(Spacing.xl, insets.bottom) },
+            !canSave && styles.saveBtnDisabled,
+            pressed && canSave && styles.saveBtnPressed,
+          ]}
+          onPress={handleSave}
+          disabled={!canSave}
+          accessibilityRole="button"
+          accessibilityLabel="Save vacation"
+        >
+          {submitting ? <ActivityIndicator color={Colors.textInverse} /> : <Text style={styles.saveText}>Create vacation</Text>}
+        </Pressable>
+      </KeyboardAvoidingView>
     </View>
   );
 }
@@ -181,9 +198,10 @@ const styles = StyleSheet.create({
   root: { flex: 1, backgroundColor: Colors.bg },
   header: {
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-    paddingHorizontal: Spacing.lg, paddingTop: 56, paddingBottom: Spacing.md,
+    paddingHorizontal: Spacing.lg, paddingBottom: Spacing.md,
   },
   headerTitle: { fontSize: 17, fontWeight: '700', color: Colors.textPrimary },
+  keyboardAvoider: { flex: 1 },
   body: { padding: Spacing.xl },
   label: { fontSize: 13, fontWeight: '600', color: Colors.textSecondary, marginBottom: Spacing.sm, marginTop: Spacing.lg },
   hint: { fontSize: 12, color: Colors.textTertiary, marginBottom: Spacing.sm },
@@ -192,15 +210,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.md, paddingVertical: 12, fontSize: 15, color: Colors.textPrimary,
   },
   dateRow: { flexDirection: 'row', gap: Spacing.md },
-  dateInput: { flex: 1 },
+  // minWidth: 0 is required on web: flex items default to min-width:auto there,
+  // so a TextInput refuses to shrink below its intrinsic width and overflows the
+  // row. React Native has no such rule, so this is a no-op on native.
+  dateInput: { flex: 1, minWidth: 0 },
   error: { fontSize: 12, color: Colors.error, marginTop: Spacing.sm },
   groupTrigger: {
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
     backgroundColor: Colors.surface, borderRadius: Radius.md, borderWidth: 1, borderColor: Colors.border,
     paddingHorizontal: Spacing.md, paddingVertical: 12,
   },
-  groupTriggerText: { fontSize: 15, color: Colors.textPrimary },
-  groupTriggerPlaceholder: { fontSize: 15, color: Colors.textTertiary },
+  groupTriggerText: { flex: 1, fontSize: 15, color: Colors.textPrimary },
+  groupTriggerPlaceholder: { flex: 1, fontSize: 15, color: Colors.textTertiary },
   groupPanel: {
     marginTop: Spacing.sm, maxHeight: 240, borderRadius: Radius.md, borderWidth: 1, borderColor: Colors.border,
     backgroundColor: Colors.surface, ...Shadow.sm,
@@ -212,10 +233,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.md, paddingVertical: 12, marginBottom: Spacing.sm,
   },
   groupRowSelected: { borderColor: Colors.primary, backgroundColor: Colors.primaryMuted },
-  groupName: { fontSize: 15, color: Colors.textPrimary, fontWeight: '500' },
+  groupName: { flex: 1, marginRight: Spacing.sm, fontSize: 15, color: Colors.textPrimary, fontWeight: '500' },
   saveBtn: {
     backgroundColor: Colors.primary, borderRadius: Radius.lg, paddingVertical: 16,
-    justifyContent: 'center', alignItems: 'center', marginHorizontal: Spacing.xl, marginBottom: Spacing.xl, ...Shadow.sm,
+    justifyContent: 'center', alignItems: 'center', marginHorizontal: Spacing.xl, ...Shadow.sm,
   },
   saveBtnDisabled: { backgroundColor: Colors.surfaceMuted },
   saveBtnPressed: { backgroundColor: Colors.primaryDark },

--- a/mobile/components/FriendPickerSheet.tsx
+++ b/mobile/components/FriendPickerSheet.tsx
@@ -544,7 +544,7 @@ const EqualRow = memo(function EqualRow({
       <View style={[styles.avatar, { backgroundColor: avatarColor + '18' }]}>
         <Text style={[styles.avatarText, { color: avatarColor }]}>{initial}</Text>
       </View>
-      <Text style={[styles.friendName, isSelected && styles.friendNameSelected]}>
+      <Text style={[styles.friendName, isSelected && styles.friendNameSelected]} numberOfLines={1}>
         {friend.display_name}
       </Text>
       <View style={[styles.checkbox, isSelected && styles.checkboxSelected]}>

--- a/mobile/components/TransactionRow.tsx
+++ b/mobile/components/TransactionRow.tsx
@@ -47,9 +47,9 @@ export function TransactionRow({ transaction, onSkip, onSplit, onLongPress, sele
         </View>
         <View style={styles.info}>
           <Text style={styles.merchant} numberOfLines={1}>{transaction.merchant_name}</Text>
-          <Text style={styles.date}>{date}</Text>
+          <Text style={styles.date} numberOfLines={1}>{date}</Text>
         </View>
-        <Text style={styles.amount}>{amount}</Text>
+        <Text style={styles.amount} numberOfLines={1}>{amount}</Text>
       </Pressable>
     );
   }
@@ -86,7 +86,7 @@ export function TransactionRow({ transaction, onSkip, onSplit, onLongPress, sele
         <View style={styles.info}>
           <Text style={styles.merchant} numberOfLines={1}>{transaction.merchant_name}</Text>
           <View style={styles.dateRow}>
-            <Text style={styles.date}>{date}</Text>
+            <Text style={styles.date} numberOfLines={1}>{date}</Text>
             {transaction.pending && (
               <View style={styles.pendingBadge}>
                 <Text style={styles.pendingText}>Pending</Text>
@@ -96,7 +96,7 @@ export function TransactionRow({ transaction, onSkip, onSplit, onLongPress, sele
         </View>
 
         {/* Amount */}
-        <Text style={styles.amount}>{amount}</Text>
+        <Text style={styles.amount} numberOfLines={1}>{amount}</Text>
 
         {/* Actions */}
         <View style={styles.actions}>
@@ -146,7 +146,12 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: '700',
   },
-  info: { flex: 1, marginRight: Spacing.sm },
+  // minWidth keeps the merchant name legible when the amount is unusually wide:
+  // without a floor, a large amount takes its intrinsic width first and crushes
+  // this column to a few pixels. Keep the floor below the ~75px this column gets
+  // naturally for a typical amount, or it steals width back and truncates every
+  // amount instead.
+  info: { flex: 1, minWidth: 64, marginRight: Spacing.sm },
   merchant: {
     fontSize: 15,
     fontWeight: '600',
@@ -167,6 +172,7 @@ const styles = StyleSheet.create({
     borderRadius: Radius.sm,
     paddingHorizontal: 5,
     paddingVertical: 1,
+    flexShrink: 0,
   },
   pendingText: {
     fontSize: 10,
@@ -178,6 +184,8 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: Colors.textPrimary,
     marginRight: Spacing.md,
+    // Yields before the merchant name does, rather than pushing it off the row.
+    flexShrink: 1,
   },
   actions: { flexDirection: 'row', gap: 6 },
   btn: {

--- a/mobile/components/VacationBanner.tsx
+++ b/mobile/components/VacationBanner.tsx
@@ -32,8 +32,8 @@ export function VacationBanner() {
           <Ionicons name="airplane-outline" size={18} color={Colors.primary} />
         </View>
         <View style={styles.info}>
-          <Text style={styles.title}>{inProgress.name}</Text>
-          <Text style={styles.subtitle}>
+          <Text style={styles.title} numberOfLines={1}>{inProgress.name}</Text>
+          <Text style={styles.subtitle} numberOfLines={1}>
             {inProgress.start_date && inProgress.end_date
               ? `${inProgress.start_date} – ${inProgress.end_date}`
               : inProgress.status === 'active' ? 'Active vacation' : 'Not started yet'}
@@ -56,8 +56,9 @@ export function VacationBanner() {
           <Ionicons name="airplane-outline" size={18} color={Colors.primary} />
         </View>
         <View style={styles.info}>
-          <Text style={styles.title}>Track vacation spending separately</Text>
-          <Text style={styles.subtitle}>Create a vacation</Text>
+          {/* Static copy, not user data — let it wrap rather than truncate. */}
+          <Text style={styles.title} numberOfLines={2}>Track vacation spending separately</Text>
+          <Text style={styles.subtitle} numberOfLines={1}>Create a vacation</Text>
         </View>
         <Ionicons name="chevron-forward" size={18} color={Colors.textTertiary} />
       </Pressable>

--- a/mobile/jest.setup.ts
+++ b/mobile/jest.setup.ts
@@ -11,3 +11,12 @@ jest.mock('expo-secure-store', () => ({
 // Render icon families as no-op components so component tests don't pull in
 // expo-font's native font loader (which throws in the jest-expo environment).
 jest.mock('@expo/vector-icons', () => new Proxy({}, { get: () => () => null }));
+
+// Screens that pad around the notch/home indicator call useSafeAreaInsets, which
+// throws without a provider above it. Tests render screens in isolation, so stub
+// the whole module here rather than wrapping every render in a provider.
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));


### PR DESCRIPTION
Fixes text and controls that overflowed or overlapped on narrow screens.

I audited all 15 screens/components statically, then **ran the PWA at a 375px viewport** with deliberately long merchant, friend, group and account names. Running it mattered — three of these are web-only and neither the test suite nor a native build would have surfaced them.

## Overflow found by running the app

**Date inputs ran 43px off-screen** (`vacation/new.tsx`)
Computed style was `flex: 1 1 0%` with `min-width: auto`; the second input's right edge landed at 418px in a 375px viewport. On the web, flex items refuse to shrink below their intrinsic content width — React Native has no such rule, so `flex: 1` is correct on native and broken in the PWA. Fixed with `minWidth: 0`, a no-op on native.

**A large amount crushed the transaction row** (`TransactionRow.tsx`)
Measured: the info column collapsed to **25px wide × 50px tall** — the date had wrapped to a second line and collided with the "Pending" badge. The column now has a floor and the amount yields first.

Note the floor is deliberately `64`, not higher: the column's natural width in this row is ~75px, and a floor above that steals width back from the amount and truncates *every* amount, including `$12.50`. Verified `$12.50` renders in full.

**The vacation group chip overran the screen edge** (`vacation/[id].tsx`)
363px wide with `flex-shrink: 0`. `numberOfLines={1}` alone can't ellipsize when nothing bounds the width.

## Safe areas

- **Root `SafeAreaProvider` added.** `FriendPickerSheet` and `AddToVacationSheet` already called `useSafeAreaInsets` and only resolved via the navigator's implicit `SafeAreaProviderCompat`.
- **Tab bar collided with the home indicator** — it hardcoded `height: 60` / `paddingBottom: 4`, overriding React Navigation's safe-area sizing, so labels rendered inside the 34pt strip.
- **`Constants.statusBarHeight` → `useSafeAreaInsets().top` everywhere.** expo-constants returns a literal `0` for `statusBarHeight` on web (`ExponentConstants.web.js`), and this ships as a PWA. `react-native-safe-area-context` reads `env(safe-area-inset-*)` and is correct on both platforms.
- **The two select bars needed opposite fixes.** The Transactions one sits inside a Tabs navigator, where the content area already stops above the tab bar, so `bottom: 0` is right and insets would double-count. The vacation one is a Stack screen sitting directly on the home indicator and does need `insets.bottom`. Both lists now reserve bottom padding in select mode — previously the last row was unreachable underneath the bar.
- **Keyboard no longer covers the "Create vacation" CTA.**

## Truncation

`numberOfLines` on merchant names, friend-name lists (a 6-friend split was rendering a 3–4 line badge), vacation names, banner titles, profile name and institution name. Static banner copy wraps to two lines rather than truncating — ellipsizing fixed marketing copy is worse than letting it wrap.

## Testing

`react-native-safe-area-context` is now mocked globally in `jest.setup.ts`. Five files use insets; per-file mocks would keep breaking as more screens adopt them.

`npx tsc --noEmit` clean. 251 tests across 25 suites pass.

## Reviewer notes

- `vacation/new.tsx` shows +233/−148 mostly because wrapping the body in `KeyboardAvoidingView` re-indented ~107 lines. The behavioural change is small.
- `FriendPickerSheet.tsx` is a one-line `numberOfLines` addition; its footer/ref/`BottomSheetFlatList` structure from #63 is untouched.
- **Not verified:** the friend rows inside `FriendPickerSheet`, which need a live Splitwise session to populate. Everything else was confirmed visually plus by measuring computed styles in the page.

## Out of scope, filed separately

Deep-linking to a tab route crashes with `DB not initialized` — `reconcileVacations()` runs in the tabs layout effect while `initDb()` is still awaiting in the root layout, and React runs child effects before parent effects. Pre-existing and unrelated to layout, so it is not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
