### PR TITLE
fix: use the device's local time for all calendar dates

### DIFF
--- a/mobile/__tests__/lib/date.test.ts
+++ b/mobile/__tests__/lib/date.test.ts
@@ -1,0 +1,52 @@
+import { formatDayLabel, parseLocalDate, toLocalDateString, todayLocal } from '@/lib/date';
+
+// These assertions hold in every timezone, which is the point: a calendar date
+// must survive storage and display unchanged no matter where the device is.
+// The old `new Date(str)` / `toISOString()` implementations satisfied them only
+// at UTC+0 or east of it.
+describe('calendar dates are handled in the device timezone', () => {
+  test('a stored date renders as that same day, not the UTC-shifted one', () => {
+    expect(formatDayLabel('2026-08-06')).toBe('Aug 6');
+    expect(formatDayLabel('2026-01-01')).toBe('Jan 1');
+    // New Year's Day is the sharpest case: parsed as UTC midnight it renders as
+    // Dec 31 of the previous year anywhere west of UTC.
+    expect(formatDayLabel('2026-12-31')).toBe('Dec 31');
+  });
+
+  test('parseLocalDate lands on local midnight of the named day', () => {
+    const d = parseLocalDate('2026-08-06');
+    expect([d.getFullYear(), d.getMonth(), d.getDate()]).toEqual([2026, 7, 6]);
+    expect([d.getHours(), d.getMinutes()]).toEqual([0, 0]);
+  });
+
+  test('a full instant still renders in local time', () => {
+    // Not a bare date, so it is a real moment and Date already localises it.
+    const iso = '2026-08-06T12:00:00.000Z';
+    expect(parseLocalDate(iso).getTime()).toBe(Date.parse(iso));
+  });
+
+  test('date strings round-trip unchanged', () => {
+    for (const s of ['2026-01-01', '2026-06-15', '2026-12-31']) {
+      expect(toLocalDateString(parseLocalDate(s))).toBe(s);
+    }
+  });
+
+  test('todayLocal is the device calendar date, not the UTC one', () => {
+    const now = new Date();
+    const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
+      now.getDate()
+    ).padStart(2, '0')}`;
+    expect(todayLocal()).toBe(expected);
+  });
+
+  test('todayLocal tracks the device clock across the local midnight boundary', () => {
+    // 11:30pm local on Aug 6 is already Aug 7 in UTC for any western zone. The
+    // vacation reconciler keys off this value, so getting it wrong starts and
+    // ends trips on the wrong day.
+    jest.useFakeTimers().setSystemTime(new Date(2026, 7, 6, 23, 30));
+    expect(todayLocal()).toBe('2026-08-06');
+    jest.setSystemTime(new Date(2026, 7, 7, 0, 30));
+    expect(todayLocal()).toBe('2026-08-07');
+    jest.useRealTimers();
+  });
+});

--- a/mobile/__tests__/lib/db.web.test.ts
+++ b/mobile/__tests__/lib/db.web.test.ts
@@ -12,7 +12,19 @@ import {
   rekeyTransaction, markTransactionsReversed, getReviewTransactions, clearReview,
 } from '@/lib/db.web';
 import { PlaidTransaction, SplitDecision } from '@/lib/types';
+import { toLocalDateString } from '@/lib/date';
 import { VacationConflictError } from '@/lib/vacationErrors';
+
+// Relative calendar dates have to be built in local time, the same way
+// reconcileVacationStatuses computes "today". Deriving them from
+// `toISOString()` instead makes these tests fail whenever the device's date
+// and the UTC date disagree — e.g. any evening in US Pacific, where "yesterday"
+// via UTC comes back as today's local date and nothing looks elapsed.
+function localDate(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return toLocalDateString(d);
+}
 
 function plaidTx(id: string, over: Partial<PlaidTransaction> = {}): PlaidTransaction {
   return {
@@ -559,19 +571,16 @@ describe('vacation transaction capture & history (IndexedDB)', () => {
   });
 
   it('reconcileVacationStatuses activates a draft whose start date has arrived', async () => {
-    const past = new Date(); past.setDate(past.getDate() - 1);
-    const v = await createVacation({ name: 'Hawaii', start_date: past.toISOString().slice(0, 10), end_date: '2099-01-01' });
+    const v = await createVacation({ name: 'Hawaii', start_date: localDate(-1), end_date: '2099-01-01' });
     await reconcileVacationStatuses();
     expect((await getVacation(v.id))?.status).toBe('active');
   });
 
   it('reconcileVacationStatuses ends an active vacation whose end date has passed', async () => {
-    const past = new Date(); past.setDate(past.getDate() - 5);
-    const pastEnd = new Date(); pastEnd.setDate(pastEnd.getDate() - 1);
     const v = await createVacation({
       name: 'Hawaii',
-      start_date: past.toISOString().slice(0, 10),
-      end_date: pastEnd.toISOString().slice(0, 10),
+      start_date: localDate(-5),
+      end_date: localDate(-1),
     });
     await startVacation(v.id);
     await reconcileVacationStatuses();
@@ -588,8 +597,7 @@ describe('vacation transaction capture & history (IndexedDB)', () => {
     // Both have start_date in the past and no end_date, so createVacation's
     // overlap check (which only runs when both dates are set) never rejects
     // the second one — this is the scenario the native LIMIT-1 fix guards.
-    const past = new Date(); past.setDate(past.getDate() - 3);
-    const startDate = past.toISOString().slice(0, 10);
+    const startDate = localDate(-3);
     const a = await createVacation({ name: 'A', start_date: startDate });
     const b = await createVacation({ name: 'B', start_date: startDate });
     await reconcileVacationStatuses();
@@ -598,14 +606,11 @@ describe('vacation transaction capture & history (IndexedDB)', () => {
   });
 
   it('reconcileVacationStatuses ends a draft immediately if both its dates have already elapsed, without blocking a later activation', async () => {
-    const wayPast = new Date(); wayPast.setDate(wayPast.getDate() - 10);
-    const stillPast = new Date(); stillPast.setDate(stillPast.getDate() - 5);
-    const recentPast = new Date(); recentPast.setDate(recentPast.getDate() - 1);
     const elapsed = await createVacation({
-      name: 'Elapsed', start_date: wayPast.toISOString().slice(0, 10), end_date: stillPast.toISOString().slice(0, 10),
+      name: 'Elapsed', start_date: localDate(-10), end_date: localDate(-5),
     });
     const current = await createVacation({
-      name: 'Current', start_date: recentPast.toISOString().slice(0, 10),
+      name: 'Current', start_date: localDate(-1),
     });
     await reconcileVacationStatuses();
     expect((await getVacation(elapsed.id))?.status).toBe('ended');
@@ -613,14 +618,11 @@ describe('vacation transaction capture & history (IndexedDB)', () => {
   });
 
   it('reconcileVacationStatuses activates a new draft the same day an active vacation elapses', async () => {
-    const farPast = new Date(); farPast.setDate(farPast.getDate() - 10);
-    const yesterday = new Date(); yesterday.setDate(yesterday.getDate() - 1);
-    const today = new Date().toISOString().slice(0, 10);
     const a = await createVacation({
-      name: 'A', start_date: farPast.toISOString().slice(0, 10), end_date: yesterday.toISOString().slice(0, 10),
+      name: 'A', start_date: localDate(-10), end_date: localDate(-1),
     });
     await startVacation(a.id);
-    const b = await createVacation({ name: 'B', start_date: today, end_date: null });
+    const b = await createVacation({ name: 'B', start_date: localDate(0), end_date: null });
     await reconcileVacationStatuses();
     expect((await getVacation(a.id))?.status).toBe('ended');
     expect((await getVacation(b.id))?.status).toBe('active');

--- a/mobile/app/(tabs)/history.tsx
+++ b/mobile/app/(tabs)/history.tsx
@@ -7,6 +7,7 @@ import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { showDialog } from '@/lib/dialog';
 import { getHistoryTransactions, getSplitDecision, getTransactionsByIds } from '@/lib/db';
 import { HistoryItem, SplitDecision, Transaction } from '@/lib/types';
+import { formatDayLabel } from '@/lib/date';
 import { useTransactionStore } from '@/stores/transactionStore';
 import { FriendPickerSheet } from '@/components/FriendPickerSheet';
 import { HistoryActionSheet } from '@/components/HistoryActionSheet';
@@ -214,7 +215,7 @@ function EmptyState() {
 }
 
 function HistoryRow({ item, onPress }: { item: HistoryItem; onPress: () => void }) {
-  const date = new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const date = formatDayLabel(item.date);
   const isSplit = item.status === 'split' && item.split;
   const initial = (item.merchant_name ?? '?')[0].toUpperCase();
   const avatarColor = merchantColor(item.merchant_name ?? '?');

--- a/mobile/components/TransactionRow.tsx
+++ b/mobile/components/TransactionRow.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
 import { Ionicons } from '@expo/vector-icons';
 import { Transaction } from '@/lib/types';
+import { formatDayLabel } from '@/lib/date';
 import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
 
 interface Props {
@@ -18,10 +19,7 @@ interface Props {
 
 export function TransactionRow({ transaction, onSkip, onSplit, onLongPress, selectMode, selected, onToggleSelect, variant = 'skip' }: Props) {
   const amount = `$${transaction.amount.toFixed(2)}`;
-  const date = new Date(transaction.date).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-  });
+  const date = formatDayLabel(transaction.date);
   const initial = (transaction.merchant_name ?? '?')[0].toUpperCase();
   const avatarBg = merchantColor(transaction.merchant_name ?? '?');
   const removeMode = variant === 'remove';

--- a/mobile/lib/date.ts
+++ b/mobile/lib/date.ts
@@ -1,0 +1,57 @@
+// mobile/lib/date.ts
+//
+// Calendar dates vs. instants — the app deals in both, and they need opposite
+// treatment:
+//
+//   * A *calendar date* ("YYYY-MM-DD": Transaction.date, Vacation.start_date /
+//     end_date) names a day on the user's wall calendar. It has no time and no
+//     zone, and must always be produced and read back in the device's local
+//     time. `new Date("2026-08-06")` does NOT do that: ECMA-262 parses the
+//     date-only form as UTC midnight, so in any zone west of UTC it renders as
+//     the previous day. Likewise `new Date().toISOString().slice(0, 10)` yields
+//     the UTC date, which in PDT flips over at 5pm local. Use the helpers here
+//     instead of either.
+//
+//   * An *instant* (created_at, started_at, ended_at) is a moment in time, and
+//     stays stored as a UTC ISO-8601 string. That keeps it unambiguous and
+//     keeps lexicographic string comparison equal to chronological order, which
+//     `pruneOldTransactions` relies on. Convert to local only when displaying.
+
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+/** The calendar date of `d` in the device's local time, as "YYYY-MM-DD". */
+export function toLocalDateString(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Today's calendar date on the device, as "YYYY-MM-DD". */
+export function todayLocal(): string {
+  return toLocalDateString(new Date());
+}
+
+/**
+ * Parse a stored date for display. A bare "YYYY-MM-DD" becomes local midnight
+ * of that same day (never shifted by the zone offset); anything else is an
+ * instant and is parsed as-is, since `Date` already renders those in local
+ * time.
+ */
+export function parseLocalDate(value: string): Date {
+  const match = DATE_ONLY_RE.test(value);
+  if (!match) return new Date(value);
+  const [y, m, d] = value.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+/**
+ * Short "Aug 6"-style label for a stored date, in the device's local time.
+ * The locale stays pinned to en-US to match the rest of the app's copy; only
+ * the zone handling is what changed here.
+ */
+export function formatDayLabel(value: string): string {
+  return parseLocalDate(value).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/mobile/lib/db.ts
+++ b/mobile/lib/db.ts
@@ -3,6 +3,7 @@ import * as SQLite from 'expo-sqlite';
 import { Transaction, PlaidTransaction, SplitDecision, TransactionStatus, HistoryItem, ReviewItem, ReviewReason, RekeyResult } from '@/lib/types';
 import { Vacation, CreateVacationInput, VacationStatus } from '@/lib/types';
 import { generateId } from '@/lib/id';
+import { todayLocal } from '@/lib/date';
 import { VacationConflictError } from '@/lib/vacationErrors';
 
 let _db: SQLite.SQLiteDatabase | null = null;
@@ -295,7 +296,10 @@ export async function removeTransactionFromVacation(transactionId: string): Prom
 }
 
 export async function reconcileVacationStatuses(): Promise<void> {
-  const today = new Date().toISOString().slice(0, 10);
+  // `today` is the device's local calendar date, so a vacation starts and ends
+  // at the user's midnight rather than UTC's (see lib/date.ts). `now` is an
+  // instant and stays UTC.
+  const today = todayLocal();
   const now = new Date().toISOString();
   await db().withTransactionAsync(async () => {
     // 1. A draft whose entire window has already elapsed (past start AND

--- a/mobile/lib/db.web.ts
+++ b/mobile/lib/db.web.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/types';
 import { Vacation, CreateVacationInput, VacationStatus } from '@/lib/types';
 import { generateId } from '@/lib/id';
+import { todayLocal } from '@/lib/date';
 import { VacationConflictError } from '@/lib/vacationErrors';
 
 const DB_NAME = 'spliteasy';
@@ -263,7 +264,10 @@ export async function removeTransactionFromVacation(transactionId: string): Prom
 }
 
 export async function reconcileVacationStatuses(): Promise<void> {
-  const today = new Date().toISOString().slice(0, 10);
+  // `today` is the device's local calendar date, so a vacation starts and ends
+  // at the user's midnight rather than UTC's (see lib/date.ts). `now` is an
+  // instant and stays UTC.
+  const today = todayLocal();
   const now = new Date().toISOString();
   const tx = db().transaction(VACATION_STORE, 'readwrite');
   const store = tx.objectStore(VACATION_STORE);


### PR DESCRIPTION
## The bug

Vacations started and ended on **UTC midnight**, and transaction dates rendered **a day early**. Both are wrong for any device west of UTC. Captured live at 5:55pm PDT:

```
device TZ   : America/Los_Angeles
UTC today   : 2026-08-07     ← what the app thought "today" was
local today : 2026-08-06
"2026-08-06" rendered as: Aug 5
```

### 1. Vacation start/stop ran on UTC midnight

`reconcileVacationStatuses` derived `today` from `new Date().toISOString().slice(0, 10)` — the UTC date. In US Pacific that rolls over at **5pm local**, so a vacation dated Aug 7 auto-activated at 5pm on Aug 6, and one ending Aug 10 ended at 5pm on Aug 9.

### 2. Every transaction date displayed one day early

`TransactionRow` and the history screen formatted with `new Date("2026-08-06")`. ECMA-262 parses the date-only form as UTC midnight, which `toLocaleDateString` then converts back to local time — landing at 5pm the previous day.

## The fix

New `lib/date.ts` draws the distinction the app was missing:

- **Calendar dates** (`"YYYY-MM-DD"`: `Transaction.date`, `Vacation.start_date`/`end_date`) name a day on the user's wall calendar. Always produced and read in local time now, via `todayLocal()` / `parseLocalDate()` / `formatDayLabel()`.
- **Instants** (`created_at`, `started_at`, `ended_at`) stay stored as **UTC ISO-8601**. This is deliberate: it keeps them unambiguous and keeps lexicographic string comparison equal to chronological order, which `pruneOldTransactions`' `created_at < cutoffIso` check depends on. None are displayed today; when they are, they should be converted at render time.

Vacation dates in the UI were already correct — they're printed as the raw stored string and never round-tripped through a `Date`.

## Tests

Two vacation-reconcile tests in `db.web.test.ts` built their relative dates the same UTC way, so they were **themselves timezone-dependent** and failed once the reconciler moved to local time: at 5:55pm Pacific their "yesterday" was already today's local date, so nothing looked elapsed. They'd have failed on a Pacific machine any evening. Now use a local `localDate(offsetDays)` helper.

The new `date.test.ts` cases were verified to go red against the old implementation before being kept:

```
✕ OLD formatDayLabel                      Expected: "Aug 6"       Received: "Aug 5"
✕ OLD todayLocal across local midnight    Expected: "2026-08-06"  Received: "2026-08-07"
```

Its assertions hold in every timezone, which is the point — a calendar date must survive storage and display unchanged regardless of where the device is.

## Verification

- `npx tsc --noEmit` — clean
- `npx jest` — **257 passed, 26 suites**

## Reviewer note

The one place "device local time" is *not* applied literally is instant storage, for the prune-ordering reason above. If that tradeoff looks wrong, the alternative is storing instants with an explicit offset and comparing parsed values rather than strings — a larger change than this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4yNBGWGvDeJhEj2V4N1j1