### PR TITLE
feat: pick and edit vacation dates on a calendar

### DIFF
--- a/mobile/__tests__/app/vacation-new.test.tsx
+++ b/mobile/__tests__/app/vacation-new.test.tsx
@@ -10,9 +10,17 @@ import { render, fireEvent, screen, waitFor, act } from '@testing-library/react-
 import NewVacationScreen from '@/app/vacation/new';
 import { useVacationStore } from '@/stores/vacationStore';
 import { getGroups } from '@/lib/splitwise';
+import { formatDayLabelWithYear, toLocalDateString, yearMonthOf } from '@/lib/date';
 import { SplitwiseGroup } from '@/lib/types';
 
 const mockGetGroups = getGroups as jest.Mock;
+const mockCreate = jest.fn();
+
+// Addressed by real label rather than a fixed date so the suite doesn't drift
+// as the calendar month changes.
+const thisMonth = yearMonthOf(null);
+const dayOf = (day: number) => toLocalDateString(new Date(thisMonth.year, thisMonth.month, day));
+const dayLabel = (day: number) => formatDayLabelWithYear(dayOf(day));
 
 const groups: SplitwiseGroup[] = [
   { id: '1', name: 'Hawaii Crew', member_ids: ['1', '2'], member_names: ['A', 'B'] },
@@ -21,9 +29,15 @@ const groups: SplitwiseGroup[] = [
 
 beforeEach(() => {
   jest.clearAllMocks();
-  (useVacationStore as unknown as jest.Mock).mockImplementation((sel) => sel({ create: jest.fn() }));
+  mockCreate.mockResolvedValue({ id: 'vac_1' });
+  (useVacationStore as unknown as jest.Mock).mockImplementation((sel) => sel({ create: mockCreate }));
   mockGetGroups.mockResolvedValue(groups);
 });
+
+async function renderScreen() {
+  render(<NewVacationScreen />);
+  await waitFor(() => expect(screen.getByLabelText('Select dates')).toBeTruthy());
+}
 
 test('the group dropdown is collapsed by default and reveals options on tap', async () => {
   render(<NewVacationScreen />);
@@ -53,4 +67,56 @@ test('selecting a group updates the trigger label and collapses the list', async
 
   expect(screen.getByText('Roommates')).toBeTruthy();
   expect(screen.queryByLabelText('Hawaii Crew')).toBeNull();
+});
+
+test('a range picked on the calendar is saved as the vacation dates', async () => {
+  await renderScreen();
+
+  fireEvent.changeText(screen.getByLabelText('Vacation name'), 'Hawaii');
+  fireEvent.press(screen.getByLabelText('Select dates'));
+  fireEvent.press(screen.getByLabelText(dayLabel(10)));
+  fireEvent.press(screen.getByLabelText(dayLabel(17)));
+
+  await act(async () => {
+    fireEvent.press(screen.getByLabelText('Save vacation'));
+  });
+
+  expect(mockCreate).toHaveBeenCalledWith(
+    expect.objectContaining({ name: 'Hawaii', start_date: dayOf(10), end_date: dayOf(17) })
+  );
+});
+
+test('a vacation with no dates saves them as null', async () => {
+  await renderScreen();
+
+  fireEvent.changeText(screen.getByLabelText('Vacation name'), 'Manual');
+  await act(async () => {
+    fireEvent.press(screen.getByLabelText('Save vacation'));
+  });
+
+  expect(mockCreate).toHaveBeenCalledWith(
+    expect.objectContaining({ start_date: null, end_date: null })
+  );
+});
+
+test('a half-picked range blocks saving until the end date is chosen', async () => {
+  await renderScreen();
+
+  fireEvent.changeText(screen.getByLabelText('Vacation name'), 'Hawaii');
+  fireEvent.press(screen.getByLabelText('Select dates'));
+  fireEvent.press(screen.getByLabelText(dayLabel(10)));
+
+  await act(async () => {
+    fireEvent.press(screen.getByLabelText('Save vacation'));
+  });
+  // Saving now would persist a start with no end, which the reconciler would
+  // treat as an open-ended vacation the user never asked for.
+  expect(mockCreate).not.toHaveBeenCalled();
+  expect(screen.getByText('Pick an end date to finish the range.')).toBeTruthy();
+
+  fireEvent.press(screen.getByLabelText(dayLabel(17)));
+  await act(async () => {
+    fireEvent.press(screen.getByLabelText('Save vacation'));
+  });
+  expect(mockCreate).toHaveBeenCalledTimes(1);
 });

--- a/mobile/__tests__/components/DateRangePicker.test.tsx
+++ b/mobile/__tests__/components/DateRangePicker.test.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import { render, fireEvent, screen } from '@testing-library/react-native';
+import { DateRangePicker } from '@/components/DateRangePicker';
+import {
+  addMonths,
+  formatDayLabelWithYear,
+  formatMonthLabel,
+  toLocalDateString,
+  yearMonthOf,
+} from '@/lib/date';
+
+// Days are addressed by their real accessibility label rather than a
+// hard-coded date, so the suite doesn't drift as the calendar month changes.
+const thisMonth = yearMonthOf(null);
+const dayLabel = (day: number) =>
+  formatDayLabelWithYear(toLocalDateString(new Date(thisMonth.year, thisMonth.month, day)));
+const dayValue = (day: number) => toLocalDateString(new Date(thisMonth.year, thisMonth.month, day));
+
+function Harness({ onChange }: { onChange?: (s: string | null, e: string | null) => void } = {}) {
+  const [range, setRange] = useState<{ start: string | null; end: string | null }>({
+    start: null,
+    end: null,
+  });
+  return (
+    <DateRangePicker
+      startDate={range.start}
+      endDate={range.end}
+      onChange={(start, end) => {
+        setRange({ start, end });
+        onChange?.(start, end);
+      }}
+    />
+  );
+}
+
+function openCalendar() {
+  fireEvent.press(screen.getByLabelText('Select dates'));
+}
+
+test('the calendar is collapsed until the trigger is tapped', () => {
+  render(<Harness />);
+
+  expect(screen.getByText('Any dates')).toBeTruthy();
+  expect(screen.queryByLabelText(dayLabel(10))).toBeNull();
+
+  openCalendar();
+
+  expect(screen.getByLabelText(dayLabel(10))).toBeTruthy();
+  expect(screen.getByText(formatMonthLabel(thisMonth))).toBeTruthy();
+});
+
+test('picking a start then an end emits the range and collapses the calendar', () => {
+  const onChange = jest.fn();
+  render(<Harness onChange={onChange} />);
+  openCalendar();
+
+  fireEvent.press(screen.getByLabelText(dayLabel(10)));
+  expect(onChange).toHaveBeenLastCalledWith(dayValue(10), null);
+  // Still open, prompting for the other half of the range.
+  expect(screen.getByText('Now pick the end date')).toBeTruthy();
+
+  fireEvent.press(screen.getByLabelText(dayLabel(17)));
+  expect(onChange).toHaveBeenLastCalledWith(dayValue(10), dayValue(17));
+  expect(screen.queryByLabelText(dayLabel(10))).toBeNull();
+});
+
+test('tapping before the pending start restarts the range instead of inverting it', () => {
+  const onChange = jest.fn();
+  render(<Harness onChange={onChange} />);
+  openCalendar();
+
+  fireEvent.press(screen.getByLabelText(dayLabel(17)));
+  fireEvent.press(screen.getByLabelText(dayLabel(10)));
+
+  // An end date before the start would break the `start_date <= end_date`
+  // invariant the vacation reconciler depends on, so it becomes a new start.
+  expect(onChange).toHaveBeenLastCalledWith(dayValue(10), null);
+  expect(screen.getByText('Now pick the end date')).toBeTruthy();
+});
+
+test('a single-day trip is allowed', () => {
+  const onChange = jest.fn();
+  render(<Harness onChange={onChange} />);
+  openCalendar();
+
+  fireEvent.press(screen.getByLabelText(dayLabel(12)));
+  fireEvent.press(screen.getByLabelText(dayLabel(12)));
+
+  expect(onChange).toHaveBeenLastCalledWith(dayValue(12), dayValue(12));
+});
+
+test('the month arrows move the visible month without touching the selection', () => {
+  render(<Harness />);
+  openCalendar();
+
+  fireEvent.press(screen.getByLabelText('Next month'));
+  expect(screen.getByText(formatMonthLabel(addMonths(thisMonth, 1)))).toBeTruthy();
+
+  fireEvent.press(screen.getByLabelText('Previous month'));
+  fireEvent.press(screen.getByLabelText('Previous month'));
+  expect(screen.getByText(formatMonthLabel(addMonths(thisMonth, -1)))).toBeTruthy();
+
+  expect(screen.getByText('Tap a start and end date')).toBeTruthy();
+});
+
+test('clear resets a chosen range', () => {
+  const onChange = jest.fn();
+  render(<Harness onChange={onChange} />);
+  openCalendar();
+
+  fireEvent.press(screen.getByLabelText(dayLabel(10)));
+  fireEvent.press(screen.getByLabelText(dayLabel(17)));
+  expect(screen.queryByText('Any dates')).toBeNull();
+
+  openCalendar();
+  fireEvent.press(screen.getByLabelText('Clear dates'));
+
+  expect(onChange).toHaveBeenLastCalledWith(null, null);
+  expect(screen.getByText('Any dates')).toBeTruthy();
+});
+
+test('reopening returns to the month holding the selected range', () => {
+  render(<Harness />);
+  openCalendar();
+
+  fireEvent.press(screen.getByLabelText(dayLabel(10)));
+  fireEvent.press(screen.getByLabelText(dayLabel(17)));
+
+  openCalendar();
+  fireEvent.press(screen.getByLabelText('Next month'));
+  fireEvent.press(screen.getByLabelText('Select dates')); // collapse
+  openCalendar();
+
+  // Browsing away and closing must not leave the calendar parked on an
+  // unrelated month the next time it opens.
+  expect(screen.getByText(formatMonthLabel(thisMonth))).toBeTruthy();
+});

--- a/mobile/__tests__/components/EditDatesSheet.test.tsx
+++ b/mobile/__tests__/components/EditDatesSheet.test.tsx
@@ -1,0 +1,125 @@
+// The library's own mock renders `children` only and drops `footerComponent`,
+// so the pinned CTA would never appear in the tree. Extend it, as
+// AddToVacationSheet's suite does.
+jest.mock('@gorhom/bottom-sheet', () => {
+  const React = require('react');
+  const actual = require('@gorhom/bottom-sheet/mock');
+  class BottomSheetModal extends actual.BottomSheetModal {
+    render() {
+      const content = super.render();
+      const Footer = this.props.footerComponent;
+      if (!Footer) return content;
+      return React.createElement(
+        React.Fragment,
+        null,
+        content,
+        React.createElement(Footer, { animatedFooterPosition: { value: 0 } })
+      );
+    }
+  }
+  return {
+    ...actual,
+    BottomSheetModal,
+    BottomSheetFooter: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+import { render, fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { EditDatesSheet } from '@/components/EditDatesSheet';
+import { formatDayLabelWithYear, toLocalDateString, yearMonthOf } from '@/lib/date';
+
+const thisMonth = yearMonthOf(null);
+const dayOf = (day: number) => toLocalDateString(new Date(thisMonth.year, thisMonth.month, day));
+const dayLabel = (day: number) => formatDayLabelWithYear(dayOf(day));
+
+const saved = { start: dayOf(3), end: dayOf(6) };
+
+function renderSheet(onSave = jest.fn().mockResolvedValue(undefined), openToken = 1) {
+  render(
+    <EditDatesSheet
+      startDate={saved.start}
+      endDate={saved.end}
+      openToken={openToken}
+      onSave={onSave}
+    />
+  );
+  return onSave;
+}
+
+test('the CTA renders and starts disabled, since nothing has changed yet', () => {
+  renderSheet();
+  // Regression guard: a footer-rendered CTA is invisible if the sheet ever
+  // goes back to wrapping content in BottomSheetView.
+  const cta = screen.getByLabelText('Save dates');
+  expect(cta).toBeTruthy();
+  expect(cta.props.accessibilityState?.disabled).toBe(true);
+});
+
+test('editing the range enables the CTA and saves the new dates', async () => {
+  const onSave = renderSheet();
+
+  fireEvent.press(screen.getByLabelText(dayLabel(10)));
+  fireEvent.press(screen.getByLabelText(dayLabel(17)));
+  fireEvent.press(screen.getByLabelText('Save dates'));
+
+  await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+  expect(onSave).toHaveBeenCalledWith(dayOf(10), dayOf(17));
+});
+
+test('a half-picked range leaves the CTA disabled', () => {
+  const onSave = renderSheet();
+
+  fireEvent.press(screen.getByLabelText(dayLabel(10)));
+  fireEvent.press(screen.getByLabelText('Save dates'));
+
+  // Saving a start with no end would read as an open-ended vacation.
+  expect(onSave).not.toHaveBeenCalled();
+  expect(screen.getByText('Now pick the end date')).toBeTruthy();
+});
+
+test('clearing the dates is savable and reports both as null', async () => {
+  const onSave = renderSheet();
+
+  fireEvent.press(screen.getByLabelText('Clear dates'));
+  fireEvent.press(screen.getByLabelText('Save dates'));
+
+  await waitFor(() => expect(onSave).toHaveBeenCalledWith(null, null));
+});
+
+test('the draft reseeds from the saved dates each time the sheet opens', () => {
+  const onSave = jest.fn().mockResolvedValue(undefined);
+  const { rerender } = render(
+    <EditDatesSheet startDate={saved.start} endDate={saved.end} openToken={1} onSave={onSave} />
+  );
+
+  fireEvent.press(screen.getByLabelText(dayLabel(20)));
+  expect(screen.getByText('Now pick the end date')).toBeTruthy();
+
+  // Reopening must discard the abandoned edit rather than resume it.
+  rerender(
+    <EditDatesSheet startDate={saved.start} endDate={saved.end} openToken={2} onSave={onSave} />
+  );
+
+  expect(screen.getByText('Tap a start and end date')).toBeTruthy();
+  expect(screen.getByLabelText('Save dates').props.accessibilityState?.disabled).toBe(true);
+});
+
+test('clearing after an edit saves the cleared dates, not the abandoned range', async () => {
+  const onSave = renderSheet();
+
+  // The footer is memoized on `disabled`, and this is the one sequence where
+  // the draft changes while `disabled` does not: picking a range enables the
+  // CTA, and clearing leaves it enabled (empty still differs from saved). The
+  // footer is therefore never recreated, so a handler captured in its closure
+  // would still be holding the range that was just discarded.
+  fireEvent.press(screen.getByLabelText(dayLabel(10)));
+  fireEvent.press(screen.getByLabelText(dayLabel(17)));
+  fireEvent.press(screen.getByLabelText('Clear dates'));
+  fireEvent.press(screen.getByLabelText('Save dates'));
+
+  await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+  expect(onSave).toHaveBeenCalledWith(null, null);
+});

--- a/mobile/__tests__/lib/db.test.ts
+++ b/mobile/__tests__/lib/db.test.ts
@@ -30,6 +30,7 @@ import {
   assignTransactionsToVacation,
   removeTransactionFromVacation,
   reconcileVacationStatuses,
+  updateVacationDates,
   rekeyTransaction,
   markTransactionsReversed,
   getReviewTransactions,
@@ -802,6 +803,31 @@ describe('vacation transaction capture & history', () => {
     mockDb.runAsync.mockClear();
     await assignTransactionsToVacation('vac1', []);
     expect(mockDb.runAsync).not.toHaveBeenCalled();
+  });
+
+  test('updateVacationDates excludes the vacation itself from the overlap check', async () => {
+    mockDb.getAllAsync.mockResolvedValueOnce([]);
+    await updateVacationDates('vac1', '2030-01-01', '2030-01-10');
+    const [sql, params] = mockDb.getAllAsync.mock.calls.find(([s]: [string]) =>
+      s.includes('start_date <= ?')
+    )!;
+    // Without `id != ?` a vacation always conflicts with its own saved range,
+    // making every date edit impossible.
+    expect(sql).toContain('id != ?');
+    expect(params).toEqual(['vac1', '2030-01-10', '2030-01-01']);
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('SET start_date = ?, end_date = ?'),
+      ['2030-01-01', '2030-01-10', 'vac1']
+    );
+  });
+
+  test('updateVacationDates skips the overlap query when clearing dates', async () => {
+    await updateVacationDates('vac1', null, null);
+    expect(mockDb.getAllAsync).not.toHaveBeenCalled();
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('SET start_date = ?, end_date = ?'),
+      [null, null, 'vac1']
+    );
   });
 
   test('removeTransactionFromVacation clears vacation_id for a pending row', async () => {

--- a/mobile/__tests__/lib/db.web.test.ts
+++ b/mobile/__tests__/lib/db.web.test.ts
@@ -8,7 +8,7 @@ import {
   persistCombinedSplit, revertCombinedSplit,
   createVacation, getVacations, getVacation, getActiveVacation, startVacation, endVacation, deleteVacation,
   getVacationPendingTransactions, getVacationHistory, assignTransactionsToVacation,
-  removeTransactionFromVacation, reconcileVacationStatuses,
+  removeTransactionFromVacation, reconcileVacationStatuses, updateVacationDates,
   rekeyTransaction, markTransactionsReversed, getReviewTransactions, clearReview,
 } from '@/lib/db.web';
 import { PlaidTransaction, SplitDecision } from '@/lib/types';
@@ -568,6 +568,47 @@ describe('vacation transaction capture & history (IndexedDB)', () => {
     const history = await getVacationHistory(v.id);
     expect(history).toHaveLength(1);
     expect(history[0].combined?.count).toBe(2);
+  });
+
+  it('updateVacationDates rewrites the dates of an existing vacation', async () => {
+    const v = await createVacation({ name: 'Hawaii', start_date: '2030-01-01', end_date: '2030-01-10' });
+    await updateVacationDates(v.id, '2030-02-01', '2030-02-14');
+    const updated = await getVacation(v.id);
+    expect([updated?.start_date, updated?.end_date]).toEqual(['2030-02-01', '2030-02-14']);
+  });
+
+  it('updateVacationDates clears both dates, turning the vacation manual', async () => {
+    const v = await createVacation({ name: 'Hawaii', start_date: '2030-01-01', end_date: '2030-01-10' });
+    await updateVacationDates(v.id, null, null);
+    const updated = await getVacation(v.id);
+    expect([updated?.start_date, updated?.end_date]).toEqual([null, null]);
+  });
+
+  it('updateVacationDates rejects a range overlapping another vacation', async () => {
+    await createVacation({ name: 'A', start_date: '2030-01-01', end_date: '2030-01-10' });
+    const b = await createVacation({ name: 'B', start_date: '2030-02-01', end_date: '2030-02-10' });
+    await expect(updateVacationDates(b.id, '2030-01-05', '2030-01-15')).rejects.toBeInstanceOf(
+      VacationConflictError
+    );
+    // The rejected write must not have landed.
+    expect((await getVacation(b.id))?.start_date).toBe('2030-02-01');
+  });
+
+  it('updateVacationDates does not treat a vacation as overlapping itself', async () => {
+    const v = await createVacation({ name: 'Hawaii', start_date: '2030-01-01', end_date: '2030-01-10' });
+    // Same range re-saved, and a range that still covers its own old one: both
+    // only "overlap" this vacation, which the self-exclusion has to ignore.
+    await expect(updateVacationDates(v.id, '2030-01-01', '2030-01-10')).resolves.toBeUndefined();
+    await expect(updateVacationDates(v.id, '2030-01-05', '2030-01-20')).resolves.toBeUndefined();
+    expect((await getVacation(v.id))?.end_date).toBe('2030-01-20');
+  });
+
+  it('updateVacationDates ignores overlap with an ended vacation', async () => {
+    const a = await createVacation({ name: 'A', start_date: '2030-01-01', end_date: '2030-01-10' });
+    await endVacation(a.id);
+    const b = await createVacation({ name: 'B', start_date: '2030-02-01', end_date: '2030-02-10' });
+    // Only draft and active vacations claim a date range, matching createVacation.
+    await expect(updateVacationDates(b.id, '2030-01-05', '2030-01-15')).resolves.toBeUndefined();
   });
 
   it('reconcileVacationStatuses activates a draft whose start date has arrived', async () => {

--- a/mobile/__tests__/stores/vacationStore.test.ts
+++ b/mobile/__tests__/stores/vacationStore.test.ts
@@ -9,6 +9,7 @@ const mockCreateVacation = db.createVacation as jest.Mock;
 const mockStart = db.startVacation as jest.Mock;
 const mockEnd = db.endVacation as jest.Mock;
 const mockDelete = db.deleteVacation as jest.Mock;
+const mockUpdateDates = db.updateVacationDates as jest.Mock;
 const mockReconcile = db.reconcileVacationStatuses as jest.Mock;
 
 function vac(over: Partial<Vacation> = {}): Vacation {
@@ -27,6 +28,7 @@ beforeEach(() => {
   mockStart.mockResolvedValue(undefined);
   mockEnd.mockResolvedValue(undefined);
   mockDelete.mockResolvedValue(undefined);
+  mockUpdateDates.mockResolvedValue(undefined);
   mockReconcile.mockResolvedValue(undefined);
 });
 
@@ -88,4 +90,19 @@ test('deleteVacation calls db.deleteVacation and reloads', async () => {
   await useVacationStore.getState().deleteVacation('v1');
   expect(mockDelete).toHaveBeenCalledWith('v1');
   expect(mockGetVacations).toHaveBeenCalled();
+});
+
+test('updateDates writes the dates then reconciles', async () => {
+  await useVacationStore.getState().updateDates('v1', '2030-01-01', '2030-01-10');
+  expect(mockUpdateDates).toHaveBeenCalledWith('v1', '2030-01-01', '2030-01-10');
+  // Reconciling rather than reloading is the point: edited dates can make a
+  // draft due now, or push an active vacation's end into the past, and status
+  // has to follow the dates the same way it does on create.
+  expect(mockReconcile).toHaveBeenCalledTimes(1);
+});
+
+test('updateDates propagates an overlap conflict without reconciling', async () => {
+  mockUpdateDates.mockRejectedValue(new Error('overlap'));
+  await expect(useVacationStore.getState().updateDates('v1', '2030-01-01', '2030-01-10')).rejects.toThrow();
+  expect(mockReconcile).not.toHaveBeenCalled();
 });

--- a/mobile/app/vacation/[id].tsx
+++ b/mobile/app/vacation/[id].tsx
@@ -13,7 +13,9 @@ import { TransactionRow } from '@/components/TransactionRow';
 import { FriendPickerSheet } from '@/components/FriendPickerSheet';
 import { AddToVacationSheet } from '@/components/AddToVacationSheet';
 import { useToast } from '@/components/ToastProvider';
+import { EditDatesSheet } from '@/components/EditDatesSheet';
 import { HistoryItem, Transaction } from '@/lib/types';
+import { formatDayLabel, formatDayLabelWithYear } from '@/lib/date';
 import { Colors, Radius, Shadow, Spacing, merchantColor } from '@/lib/theme';
 
 const SELECT_BAR_CONTENT_HEIGHT = 88;
@@ -28,6 +30,7 @@ export default function VacationDetailScreen() {
   const startVacation = useVacationStore((s) => s.startVacation);
   const endVacation = useVacationStore((s) => s.endVacation);
   const deleteVacation = useVacationStore((s) => s.deleteVacation);
+  const updateDates = useVacationStore((s) => s.updateDates);
   const activeVacation = useVacationStore((s) => s.activeVacation);
 
   const vacation = vacations.find((v) => v.id === id) ?? null;
@@ -39,9 +42,11 @@ export default function VacationDetailScreen() {
   const [combineTxs, setCombineTxs] = useState<Transaction[] | null>(null);
   const [pickerToken, setPickerToken] = useState(0);
   const [addToken, setAddToken] = useState(0);
-  const [pendingPresent, setPendingPresent] = useState<null | 'picker' | 'add'>(null);
+  const [datesToken, setDatesToken] = useState(0);
+  const [pendingPresent, setPendingPresent] = useState<null | 'picker' | 'add' | 'dates'>(null);
   const pickerRef = useRef<BottomSheetModal>(null);
   const addRef = useRef<BottomSheetModal>(null);
+  const datesRef = useRef<BottomSheetModal>(null);
 
   const refresh = useCallback(() => {
     if (!id) return;
@@ -64,6 +69,9 @@ export default function VacationDetailScreen() {
       setPendingPresent(null);
     } else if (pendingPresent === 'add') {
       addRef.current?.present();
+      setPendingPresent(null);
+    } else if (pendingPresent === 'dates') {
+      datesRef.current?.present();
       setPendingPresent(null);
     }
   }, [pendingPresent]);
@@ -169,8 +177,26 @@ export default function VacationDetailScreen() {
     );
   };
 
+  const handleSaveDates = async (start: string | null, end: string | null) => {
+    try {
+      await updateDates(vacation.id, start, end);
+      datesRef.current?.dismiss();
+      toast.show(start && end ? 'Dates updated' : 'Dates removed', 'success');
+    } catch (err) {
+      toast.show(
+        err instanceof VacationConflictError
+          ? 'Those dates overlap another vacation.'
+          : 'Could not update dates. Please try again.',
+        'error'
+      );
+    }
+  };
+
   const canStart = vacation.status === 'draft' && !activeVacation;
   const canEnd = vacation.status === 'active';
+  // An ended trip's dates are history — editing them would only invite a
+  // reconcile that can no longer act on them.
+  const canEditDates = vacation.status !== 'ended';
   const statusLabel = vacation.status === 'active' ? 'Active' : vacation.status === 'draft' ? 'Draft' : 'Ended';
   const mixedCurrency = new Set(pending.map((t) => t.currency)).size > 1;
 
@@ -200,8 +226,26 @@ export default function VacationDetailScreen() {
         <View style={[styles.statusPill, vacation.status === 'active' && styles.statusPillActive]}>
           <Text style={[styles.statusText, vacation.status === 'active' && styles.statusTextActive]}>{statusLabel}</Text>
         </View>
-        {vacation.start_date && vacation.end_date && (
-          <Text style={styles.dates}>{vacation.start_date} – {vacation.end_date}</Text>
+        {canEditDates ? (
+          <Pressable
+            style={styles.datesBtn}
+            onPress={() => { setDatesToken((t) => t + 1); setPendingPresent('dates'); }}
+            accessibilityRole="button"
+            accessibilityLabel={vacation.start_date ? 'Edit dates' : 'Add dates'}
+          >
+            <Ionicons name="calendar-outline" size={12} color={Colors.textSecondary} />
+            <Text style={styles.dates} numberOfLines={1}>
+              {vacation.start_date && vacation.end_date
+                ? `${formatDayLabel(vacation.start_date)} – ${formatDayLabelWithYear(vacation.end_date)}`
+                : 'Add dates'}
+            </Text>
+          </Pressable>
+        ) : (
+          vacation.start_date && vacation.end_date && (
+            <Text style={styles.dates} numberOfLines={1}>
+              {formatDayLabel(vacation.start_date)} – {formatDayLabelWithYear(vacation.end_date)}
+            </Text>
+          )
         )}
         {vacation.splitwise_group_name && (
           <View style={styles.groupChip}>
@@ -312,6 +356,13 @@ export default function VacationDetailScreen() {
         openToken={addToken}
         onDone={() => { addRef.current?.dismiss(); refresh(); }}
       />
+      <EditDatesSheet
+        ref={datesRef}
+        startDate={vacation.start_date}
+        endDate={vacation.end_date}
+        openToken={datesToken}
+        onSave={handleSaveDates}
+      />
     </View>
   );
 }
@@ -350,7 +401,10 @@ const styles = StyleSheet.create({
   statusPillActive: { backgroundColor: Colors.successLight },
   statusText: { fontSize: 11, fontWeight: '600', color: Colors.textSecondary },
   statusTextActive: { color: Colors.success },
-  dates: { fontSize: 12, color: Colors.textTertiary },
+  // flexShrink lets a long date range give way to the group chip beside it
+  // rather than pushing it off the row.
+  datesBtn: { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, flexShrink: 1, minWidth: 0 },
+  dates: { flexShrink: 1, minWidth: 0, fontSize: 12, color: Colors.textTertiary },
   // The chip must be allowed to shrink, or a long group name grows it past the
   // screen edge; numberOfLines can only ellipsize once the width is bounded.
   groupChip: { flexDirection: 'row', alignItems: 'center', gap: 4, backgroundColor: Colors.primaryMuted, borderRadius: Radius.full, paddingHorizontal: 10, paddingVertical: 4, flexShrink: 1, maxWidth: '100%' },

--- a/mobile/app/vacation/new.tsx
+++ b/mobile/app/vacation/new.tsx
@@ -9,9 +9,8 @@ import { getGroups } from '@/lib/splitwise';
 import { VacationConflictError } from '@/lib/vacationErrors';
 import { SplitwiseGroup } from '@/lib/types';
 import { useToast } from '@/components/ToastProvider';
+import { DateRangePicker } from '@/components/DateRangePicker';
 import { Colors, Radius, Shadow, Spacing } from '@/lib/theme';
-
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export default function NewVacationScreen() {
   const router = useRouter();
@@ -20,8 +19,8 @@ export default function NewVacationScreen() {
   const insets = useSafeAreaInsets();
 
   const [name, setName] = useState('');
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
+  const [startDate, setStartDate] = useState<string | null>(null);
+  const [endDate, setEndDate] = useState<string | null>(null);
   const [groups, setGroups] = useState<SplitwiseGroup[]>([]);
   const [selectedGroup, setSelectedGroup] = useState<SplitwiseGroup | null>(null);
   const [groupPickerOpen, setGroupPickerOpen] = useState(false);
@@ -31,9 +30,10 @@ export default function NewVacationScreen() {
     getGroups().then(setGroups).catch(() => setGroups([]));
   }, []);
 
-  const datesValid =
-    (startDate === '' && endDate === '') ||
-    (DATE_RE.test(startDate) && DATE_RE.test(endDate) && startDate <= endDate);
+  // The picker can only ever produce an ordered range, so the old format and
+  // ordering checks are gone. The one reachable invalid state is a half-picked
+  // range — a start with no end yet.
+  const datesValid = !startDate === !endDate;
   const canSave = name.trim() !== '' && datesValid && !submitting;
 
   async function handleSave() {
@@ -42,8 +42,8 @@ export default function NewVacationScreen() {
     try {
       const vacation = await create({
         name: name.trim(),
-        start_date: startDate || null,
-        end_date: endDate || null,
+        start_date: startDate,
+        end_date: endDate,
         splitwise_group_id: selectedGroup?.id ?? null,
         splitwise_group_name: selectedGroup?.name ?? null,
         splitwise_group_member_ids: selectedGroup?.member_ids ?? null,
@@ -88,25 +88,17 @@ export default function NewVacationScreen() {
 
           <Text style={styles.label}>Dates (optional)</Text>
           <Text style={styles.hint}>If set, the vacation starts and ends automatically on these dates.</Text>
-          <View style={styles.dateRow}>
-            <TextInput
-              style={[styles.input, styles.dateInput]}
-              value={startDate}
-              onChangeText={setStartDate}
-              placeholder="YYYY-MM-DD"
-              placeholderTextColor={Colors.textTertiary}
-              accessibilityLabel="Start date"
-            />
-            <TextInput
-              style={[styles.input, styles.dateInput]}
-              value={endDate}
-              onChangeText={setEndDate}
-              placeholder="YYYY-MM-DD"
-              placeholderTextColor={Colors.textTertiary}
-              accessibilityLabel="End date"
-            />
-          </View>
-          {!datesValid && <Text style={styles.error}>Enter both dates as YYYY-MM-DD, end on or after start.</Text>}
+          <DateRangePicker
+            startDate={startDate}
+            endDate={endDate}
+            onChange={(start, end) => {
+              setStartDate(start);
+              setEndDate(end);
+            }}
+          />
+          {startDate && !endDate && (
+            <Text style={styles.error}>Pick an end date to finish the range.</Text>
+          )}
 
           {groups.length > 0 && (
             <>
@@ -209,11 +201,6 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.surface, borderRadius: Radius.md, borderWidth: 1, borderColor: Colors.border,
     paddingHorizontal: Spacing.md, paddingVertical: 12, fontSize: 15, color: Colors.textPrimary,
   },
-  dateRow: { flexDirection: 'row', gap: Spacing.md },
-  // minWidth: 0 is required on web: flex items default to min-width:auto there,
-  // so a TextInput refuses to shrink below its intrinsic width and overflows the
-  // row. React Native has no such rule, so this is a no-op on native.
-  dateInput: { flex: 1, minWidth: 0 },
   error: { fontSize: 12, color: Colors.error, marginTop: Spacing.sm },
   groupTrigger: {
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',

--- a/mobile/components/DateRangePicker.tsx
+++ b/mobile/components/DateRangePicker.tsx
@@ -1,28 +1,14 @@
 // mobile/components/DateRangePicker.tsx
 //
-// An inline start→end calendar. Deliberately built from plain RN views rather
-// than a native date picker: SplitEasy ships as a PWA as well as iOS/Android,
-// and @react-native-community/datetimepicker has no web build. Plain views
-// render identically on all three and pick up the app's theme tokens directly.
-//
-// It mirrors the Splitwise group dropdown on the same screen — a collapsed
-// trigger that expands a panel and collapses again once the choice is complete.
-import { useEffect, useState } from 'react';
+// A collapsed trigger that expands a RangeCalendar and collapses again once
+// the range is complete — mirroring the Splitwise group dropdown that sits
+// directly below it on the new-vacation screen.
+import { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import {
-  addMonths,
-  formatDayLabel,
-  formatDayLabelWithYear,
-  formatMonthLabel,
-  monthGrid,
-  todayLocal,
-  yearMonthOf,
-  type YearMonth,
-} from '@/lib/date';
+import { RangeCalendar, RangeCalendarFooter } from '@/components/RangeCalendar';
+import { formatDayLabel, formatDayLabelWithYear } from '@/lib/date';
 import { Colors, Radius, Shadow, Spacing } from '@/lib/theme';
-
-const WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
 interface Props {
   startDate: string | null;
@@ -33,35 +19,14 @@ interface Props {
 
 export function DateRangePicker({ startDate, endDate, onChange }: Props) {
   const [open, setOpen] = useState(false);
-  const [visibleMonth, setVisibleMonth] = useState<YearMonth>(() => yearMonthOf(startDate));
+  // Bumped on open so the calendar returns to the month holding the range
+  // instead of wherever it was last browsed to.
+  const [resetToken, setResetToken] = useState(0);
 
-  // Reopening should land on the month the range already sits in rather than
-  // wherever the user last browsed to.
-  useEffect(() => {
-    if (open) setVisibleMonth(yearMonthOf(startDate));
-    // Only on open — tracking startDate here would yank the view back a month
-    // mid-selection, right after the first tap.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
-
-  function handleDayPress(date: string) {
-    // A complete range, or a tap before the pending start, begins a new range.
-    // Anything else closes the pending one.
-    if (!startDate || endDate || date < startDate) {
-      onChange(date, null);
-      return;
-    }
-    onChange(startDate, date);
-    setOpen(false);
+  function toggle() {
+    if (!open) setResetToken((t) => t + 1);
+    setOpen((v) => !v);
   }
-
-  function handleClear() {
-    onChange(null, null);
-    setOpen(false);
-  }
-
-  const today = todayLocal();
-  const weeks = monthGrid(visibleMonth);
 
   let triggerLabel = 'Any dates';
   if (startDate && endDate) {
@@ -74,7 +39,7 @@ export function DateRangePicker({ startDate, endDate, onChange }: Props) {
     <View>
       <Pressable
         style={styles.trigger}
-        onPress={() => setOpen((v) => !v)}
+        onPress={toggle}
         accessibilityRole="button"
         accessibilityLabel="Select dates"
         accessibilityState={{ expanded: open }}
@@ -87,99 +52,21 @@ export function DateRangePicker({ startDate, endDate, onChange }: Props) {
 
       {open && (
         <View style={styles.panel}>
-          <View style={styles.monthBar}>
-            <Pressable
-              onPress={() => setVisibleMonth((m) => addMonths(m, -1))}
-              style={styles.monthNav}
-              accessibilityRole="button"
-              accessibilityLabel="Previous month"
-            >
-              <Ionicons name="chevron-back" size={18} color={Colors.textPrimary} />
-            </Pressable>
-            <Text style={styles.monthLabel}>{formatMonthLabel(visibleMonth)}</Text>
-            <Pressable
-              onPress={() => setVisibleMonth((m) => addMonths(m, 1))}
-              style={styles.monthNav}
-              accessibilityRole="button"
-              accessibilityLabel="Next month"
-            >
-              <Ionicons name="chevron-forward" size={18} color={Colors.textPrimary} />
-            </Pressable>
-          </View>
-
-          <View style={styles.weekdayRow}>
-            {WEEKDAYS.map((d, i) => (
-              // Weekday initials repeat (S/T twice), so the index is the key.
-              <Text key={i} style={styles.weekday}>
-                {d}
-              </Text>
-            ))}
-          </View>
-
-          {weeks.map((week, wi) => (
-            <View key={wi} style={styles.week}>
-              {week.map((date, di) => {
-                // Leading/trailing padding still has to occupy its column, so
-                // it uses the flex cell rather than the day circle.
-                if (!date) return <View key={di} style={styles.dayCell} />;
-
-                const isStart = date === startDate;
-                const isEnd = date === endDate;
-                const inRange =
-                  !!startDate && !!endDate && date > startDate && date < endDate;
-                const isEdge = isStart || isEnd;
-
-                // The connecting band is a separate layer behind the day
-                // circle, spanning the full cell so it meets its neighbours
-                // edge to edge across the week. At the two ends it starts at
-                // the circle's centre rather than the cell edge — filling the
-                // whole end cell would read as half a day more range than was
-                // actually picked. A single-day trip gets no band at all.
-                const hasRange = !!startDate && !!endDate && startDate !== endDate;
-                let bandStyle = null;
-                if (inRange) bandStyle = styles.bandFull;
-                else if (hasRange && isStart) bandStyle = styles.bandFromCenter;
-                else if (hasRange && isEnd) bandStyle = styles.bandToCenter;
-
-                return (
-                  <View key={di} style={styles.dayCell}>
-                    {bandStyle && <View style={[styles.band, bandStyle]} />}
-                    <Pressable
-                      style={[styles.day, isEdge && styles.dayEdge]}
-                      onPress={() => handleDayPress(date)}
-                      accessibilityRole="button"
-                      accessibilityLabel={formatDayLabelWithYear(date)}
-                      accessibilityState={{ selected: isEdge || inRange }}
-                    >
-                      <Text
-                        style={[
-                          styles.dayText,
-                          date === today && !isEdge && styles.dayTextToday,
-                          isEdge && styles.dayTextEdge,
-                        ]}
-                      >
-                        {Number(date.slice(8, 10))}
-                      </Text>
-                    </Pressable>
-                  </View>
-                );
-              })}
-            </View>
-          ))}
-
-          <View style={styles.panelFooter}>
-            <Text style={styles.hint} numberOfLines={1}>
-              {startDate && !endDate ? 'Now pick the end date' : 'Tap a start and end date'}
-            </Text>
-            <Pressable
-              onPress={handleClear}
-              disabled={!startDate && !endDate}
-              accessibilityRole="button"
-              accessibilityLabel="Clear dates"
-            >
-              <Text style={[styles.clear, !startDate && !endDate && styles.clearDisabled]}>Clear</Text>
-            </Pressable>
-          </View>
+          <RangeCalendar
+            startDate={startDate}
+            endDate={endDate}
+            onChange={onChange}
+            onRangeComplete={() => setOpen(false)}
+            resetToken={resetToken}
+          />
+          <RangeCalendarFooter
+            startDate={startDate}
+            endDate={endDate}
+            onClear={() => {
+              onChange(null, null);
+              setOpen(false);
+            }}
+          />
         </View>
       )}
     </View>
@@ -200,39 +87,4 @@ const styles = StyleSheet.create({
     marginTop: Spacing.sm, borderRadius: Radius.md, borderWidth: 1, borderColor: Colors.border,
     backgroundColor: Colors.surface, padding: Spacing.sm, ...Shadow.sm,
   },
-  monthBar: {
-    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-    marginBottom: Spacing.sm,
-  },
-  monthNav: { padding: Spacing.sm, borderRadius: Radius.sm },
-  monthLabel: { flex: 1, minWidth: 0, textAlign: 'center', fontSize: 15, fontWeight: '700', color: Colors.textPrimary },
-  weekdayRow: { flexDirection: 'row', marginBottom: Spacing.xs },
-  weekday: { flex: 1, textAlign: 'center', fontSize: 11, fontWeight: '600', color: Colors.textTertiary },
-  week: { flexDirection: 'row' },
-  // minWidth: 0 lets the seven columns share the row evenly on web instead of
-  // each refusing to shrink below its content width.
-  dayCell: { flex: 1, minWidth: 0, alignItems: 'center' },
-  band: { position: 'absolute', top: 0, bottom: 0, backgroundColor: Colors.primaryMuted },
-  bandFull: { left: 0, right: 0 },
-  bandFromCenter: { left: '50%', right: 0 },
-  bandToCenter: { left: 0, right: '50%' },
-  // Sized as a share of the column rather than a fixed 38px, which would
-  // overflow seven-across on a 320px-wide screen. aspectRatio keeps the
-  // selected-day background a circle at any width.
-  day: {
-    width: '100%', maxWidth: 40, aspectRatio: 1, borderRadius: Radius.full,
-    justifyContent: 'center', alignItems: 'center',
-  },
-  dayEdge: { backgroundColor: Colors.primary },
-  dayText: { fontSize: 14, color: Colors.textPrimary },
-  dayTextToday: { color: Colors.primary, fontWeight: '700' },
-  dayTextEdge: { color: Colors.textInverse, fontWeight: '700' },
-  panelFooter: {
-    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-    marginTop: Spacing.sm, paddingHorizontal: Spacing.sm, paddingTop: Spacing.sm,
-    borderTopWidth: 1, borderTopColor: Colors.divider,
-  },
-  hint: { flex: 1, minWidth: 0, fontSize: 12, color: Colors.textTertiary },
-  clear: { fontSize: 14, fontWeight: '600', color: Colors.primary, paddingLeft: Spacing.md },
-  clearDisabled: { color: Colors.textTertiary },
 });

--- a/mobile/components/DateRangePicker.tsx
+++ b/mobile/components/DateRangePicker.tsx
@@ -1,0 +1,238 @@
+// mobile/components/DateRangePicker.tsx
+//
+// An inline start→end calendar. Deliberately built from plain RN views rather
+// than a native date picker: SplitEasy ships as a PWA as well as iOS/Android,
+// and @react-native-community/datetimepicker has no web build. Plain views
+// render identically on all three and pick up the app's theme tokens directly.
+//
+// It mirrors the Splitwise group dropdown on the same screen — a collapsed
+// trigger that expands a panel and collapses again once the choice is complete.
+import { useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  addMonths,
+  formatDayLabel,
+  formatDayLabelWithYear,
+  formatMonthLabel,
+  monthGrid,
+  todayLocal,
+  yearMonthOf,
+  type YearMonth,
+} from '@/lib/date';
+import { Colors, Radius, Shadow, Spacing } from '@/lib/theme';
+
+const WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+interface Props {
+  startDate: string | null;
+  endDate: string | null;
+  /** Emits a complete range, a start-only partial, or (null, null) when cleared. */
+  onChange: (startDate: string | null, endDate: string | null) => void;
+}
+
+export function DateRangePicker({ startDate, endDate, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const [visibleMonth, setVisibleMonth] = useState<YearMonth>(() => yearMonthOf(startDate));
+
+  // Reopening should land on the month the range already sits in rather than
+  // wherever the user last browsed to.
+  useEffect(() => {
+    if (open) setVisibleMonth(yearMonthOf(startDate));
+    // Only on open — tracking startDate here would yank the view back a month
+    // mid-selection, right after the first tap.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  function handleDayPress(date: string) {
+    // A complete range, or a tap before the pending start, begins a new range.
+    // Anything else closes the pending one.
+    if (!startDate || endDate || date < startDate) {
+      onChange(date, null);
+      return;
+    }
+    onChange(startDate, date);
+    setOpen(false);
+  }
+
+  function handleClear() {
+    onChange(null, null);
+    setOpen(false);
+  }
+
+  const today = todayLocal();
+  const weeks = monthGrid(visibleMonth);
+
+  let triggerLabel = 'Any dates';
+  if (startDate && endDate) {
+    triggerLabel = `${formatDayLabel(startDate)} – ${formatDayLabelWithYear(endDate)}`;
+  } else if (startDate) {
+    triggerLabel = `${formatDayLabelWithYear(startDate)} – pick an end date`;
+  }
+
+  return (
+    <View>
+      <Pressable
+        style={styles.trigger}
+        onPress={() => setOpen((v) => !v)}
+        accessibilityRole="button"
+        accessibilityLabel="Select dates"
+        accessibilityState={{ expanded: open }}
+      >
+        <Text style={startDate ? styles.triggerText : styles.triggerPlaceholder} numberOfLines={1}>
+          {triggerLabel}
+        </Text>
+        <Ionicons name="calendar-outline" size={18} color={Colors.textSecondary} />
+      </Pressable>
+
+      {open && (
+        <View style={styles.panel}>
+          <View style={styles.monthBar}>
+            <Pressable
+              onPress={() => setVisibleMonth((m) => addMonths(m, -1))}
+              style={styles.monthNav}
+              accessibilityRole="button"
+              accessibilityLabel="Previous month"
+            >
+              <Ionicons name="chevron-back" size={18} color={Colors.textPrimary} />
+            </Pressable>
+            <Text style={styles.monthLabel}>{formatMonthLabel(visibleMonth)}</Text>
+            <Pressable
+              onPress={() => setVisibleMonth((m) => addMonths(m, 1))}
+              style={styles.monthNav}
+              accessibilityRole="button"
+              accessibilityLabel="Next month"
+            >
+              <Ionicons name="chevron-forward" size={18} color={Colors.textPrimary} />
+            </Pressable>
+          </View>
+
+          <View style={styles.weekdayRow}>
+            {WEEKDAYS.map((d, i) => (
+              // Weekday initials repeat (S/T twice), so the index is the key.
+              <Text key={i} style={styles.weekday}>
+                {d}
+              </Text>
+            ))}
+          </View>
+
+          {weeks.map((week, wi) => (
+            <View key={wi} style={styles.week}>
+              {week.map((date, di) => {
+                // Leading/trailing padding still has to occupy its column, so
+                // it uses the flex cell rather than the day circle.
+                if (!date) return <View key={di} style={styles.dayCell} />;
+
+                const isStart = date === startDate;
+                const isEnd = date === endDate;
+                const inRange =
+                  !!startDate && !!endDate && date > startDate && date < endDate;
+                const isEdge = isStart || isEnd;
+
+                // The connecting band is a separate layer behind the day
+                // circle, spanning the full cell so it meets its neighbours
+                // edge to edge across the week. At the two ends it starts at
+                // the circle's centre rather than the cell edge — filling the
+                // whole end cell would read as half a day more range than was
+                // actually picked. A single-day trip gets no band at all.
+                const hasRange = !!startDate && !!endDate && startDate !== endDate;
+                let bandStyle = null;
+                if (inRange) bandStyle = styles.bandFull;
+                else if (hasRange && isStart) bandStyle = styles.bandFromCenter;
+                else if (hasRange && isEnd) bandStyle = styles.bandToCenter;
+
+                return (
+                  <View key={di} style={styles.dayCell}>
+                    {bandStyle && <View style={[styles.band, bandStyle]} />}
+                    <Pressable
+                      style={[styles.day, isEdge && styles.dayEdge]}
+                      onPress={() => handleDayPress(date)}
+                      accessibilityRole="button"
+                      accessibilityLabel={formatDayLabelWithYear(date)}
+                      accessibilityState={{ selected: isEdge || inRange }}
+                    >
+                      <Text
+                        style={[
+                          styles.dayText,
+                          date === today && !isEdge && styles.dayTextToday,
+                          isEdge && styles.dayTextEdge,
+                        ]}
+                      >
+                        {Number(date.slice(8, 10))}
+                      </Text>
+                    </Pressable>
+                  </View>
+                );
+              })}
+            </View>
+          ))}
+
+          <View style={styles.panelFooter}>
+            <Text style={styles.hint} numberOfLines={1}>
+              {startDate && !endDate ? 'Now pick the end date' : 'Tap a start and end date'}
+            </Text>
+            <Pressable
+              onPress={handleClear}
+              disabled={!startDate && !endDate}
+              accessibilityRole="button"
+              accessibilityLabel="Clear dates"
+            >
+              <Text style={[styles.clear, !startDate && !endDate && styles.clearDisabled]}>Clear</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  trigger: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    backgroundColor: Colors.surface, borderRadius: Radius.md, borderWidth: 1, borderColor: Colors.border,
+    paddingHorizontal: Spacing.md, paddingVertical: 12,
+  },
+  // minWidth: 0 lets the label truncate instead of pushing the icon out of the
+  // row on web, where flex items default to min-width:auto.
+  triggerText: { flex: 1, minWidth: 0, fontSize: 15, color: Colors.textPrimary },
+  triggerPlaceholder: { flex: 1, minWidth: 0, fontSize: 15, color: Colors.textTertiary },
+  panel: {
+    marginTop: Spacing.sm, borderRadius: Radius.md, borderWidth: 1, borderColor: Colors.border,
+    backgroundColor: Colors.surface, padding: Spacing.sm, ...Shadow.sm,
+  },
+  monthBar: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    marginBottom: Spacing.sm,
+  },
+  monthNav: { padding: Spacing.sm, borderRadius: Radius.sm },
+  monthLabel: { flex: 1, minWidth: 0, textAlign: 'center', fontSize: 15, fontWeight: '700', color: Colors.textPrimary },
+  weekdayRow: { flexDirection: 'row', marginBottom: Spacing.xs },
+  weekday: { flex: 1, textAlign: 'center', fontSize: 11, fontWeight: '600', color: Colors.textTertiary },
+  week: { flexDirection: 'row' },
+  // minWidth: 0 lets the seven columns share the row evenly on web instead of
+  // each refusing to shrink below its content width.
+  dayCell: { flex: 1, minWidth: 0, alignItems: 'center' },
+  band: { position: 'absolute', top: 0, bottom: 0, backgroundColor: Colors.primaryMuted },
+  bandFull: { left: 0, right: 0 },
+  bandFromCenter: { left: '50%', right: 0 },
+  bandToCenter: { left: 0, right: '50%' },
+  // Sized as a share of the column rather than a fixed 38px, which would
+  // overflow seven-across on a 320px-wide screen. aspectRatio keeps the
+  // selected-day background a circle at any width.
+  day: {
+    width: '100%', maxWidth: 40, aspectRatio: 1, borderRadius: Radius.full,
+    justifyContent: 'center', alignItems: 'center',
+  },
+  dayEdge: { backgroundColor: Colors.primary },
+  dayText: { fontSize: 14, color: Colors.textPrimary },
+  dayTextToday: { color: Colors.primary, fontWeight: '700' },
+  dayTextEdge: { color: Colors.textInverse, fontWeight: '700' },
+  panelFooter: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    marginTop: Spacing.sm, paddingHorizontal: Spacing.sm, paddingTop: Spacing.sm,
+    borderTopWidth: 1, borderTopColor: Colors.divider,
+  },
+  hint: { flex: 1, minWidth: 0, fontSize: 12, color: Colors.textTertiary },
+  clear: { fontSize: 14, fontWeight: '600', color: Colors.primary, paddingLeft: Spacing.md },
+  clearDisabled: { color: Colors.textTertiary },
+});

--- a/mobile/components/EditDatesSheet.tsx
+++ b/mobile/components/EditDatesSheet.tsx
@@ -1,0 +1,148 @@
+// mobile/components/EditDatesSheet.tsx
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import {
+  BottomSheetModal,
+  BottomSheetScrollView,
+  BottomSheetFooter,
+  type BottomSheetFooterProps,
+} from '@gorhom/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { RangeCalendar, RangeCalendarFooter } from '@/components/RangeCalendar';
+import { Colors, Radius, Shadow, Spacing } from '@/lib/theme';
+
+interface Props {
+  startDate: string | null;
+  endDate: string | null;
+  /** Bumped by the parent to reseed the draft from the saved dates on open. */
+  openToken?: number;
+  onSave: (startDate: string | null, endDate: string | null) => Promise<void>;
+}
+
+export const EditDatesSheet = forwardRef<BottomSheetModal, Props>(
+  ({ startDate, endDate, openToken, onSave }, ref) => {
+    const insets = useSafeAreaInsets();
+    // Edits are staged locally so backing out of the sheet leaves the saved
+    // dates untouched.
+    const [draftStart, setDraftStart] = useState(startDate);
+    const [draftEnd, setDraftEnd] = useState(endDate);
+    const [submitting, setSubmitting] = useState(false);
+
+    useEffect(() => {
+      setDraftStart(startDate);
+      setDraftEnd(endDate);
+      // Reseeding is keyed to opening, not to the props themselves — the
+      // parent's save triggers a store reload, and tracking the props here
+      // would stomp a fresh edit with the values still in flight.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [openToken]);
+
+    // A half-picked range would persist a start with no end, which the
+    // reconciler treats as an open-ended vacation the user never asked for.
+    const incomplete = !!draftStart && !draftEnd;
+    const unchanged = draftStart === startDate && draftEnd === endDate;
+    const disabled = incomplete || unchanged || submitting;
+
+    async function save() {
+      if (disabled) return;
+      setSubmitting(true);
+      try {
+        await onSave(draftStart, draftEnd);
+      } finally {
+        setSubmitting(false);
+      }
+    }
+
+    // The sheet renders the footer as a component type, so a change to
+    // `renderFooter`'s identity remounts the footer subtree. Route the press
+    // through a ref so the handler can't go stale on the draft dates while the
+    // deps stay narrow.
+    const saveRef = useRef(save);
+    saveRef.current = save;
+
+    const renderFooter = useCallback(
+      // The footer background is opaque so calendar rows scrolling underneath
+      // don't show through beside the button.
+      (footerProps: BottomSheetFooterProps) => (
+        <BottomSheetFooter {...footerProps} bottomInset={insets.bottom} style={styles.footer}>
+          <Pressable
+            style={({ pressed }) => [
+              styles.saveBtn,
+              disabled && styles.saveBtnDisabled,
+              pressed && !disabled && styles.saveBtnPressed,
+            ]}
+            onPress={() => saveRef.current()}
+            disabled={disabled}
+            accessibilityRole="button"
+            accessibilityLabel="Save dates"
+          >
+            {submitting ? (
+              <ActivityIndicator color={Colors.textInverse} />
+            ) : (
+              <Text style={[styles.saveText, disabled && styles.saveTextDisabled]}>Save dates</Text>
+            )}
+          </Pressable>
+        </BottomSheetFooter>
+      ),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [disabled, submitting, insets.bottom]
+    );
+
+    return (
+      <BottomSheetModal
+        ref={ref}
+        snapPoints={['80%']}
+        enableDynamicSizing={false}
+        enablePanDownToClose
+        handleIndicatorStyle={styles.indicator}
+        backgroundStyle={styles.sheetBg}
+        footerComponent={renderFooter}
+      >
+        {/* The scrollable is the direct child: BottomSheetView would override
+            its flex with position:absolute and push the footer off-screen. */}
+        <BottomSheetScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
+          <Text style={styles.title}>Edit dates</Text>
+          <Text style={styles.subtitle}>
+            The vacation starts and ends automatically on these dates.
+          </Text>
+          <RangeCalendar
+            startDate={draftStart}
+            endDate={draftEnd}
+            onChange={(start, end) => {
+              setDraftStart(start);
+              setDraftEnd(end);
+            }}
+            resetToken={openToken ?? 0}
+          />
+          <RangeCalendarFooter
+            startDate={draftStart}
+            endDate={draftEnd}
+            onClear={() => {
+              setDraftStart(null);
+              setDraftEnd(null);
+            }}
+          />
+        </BottomSheetScrollView>
+      </BottomSheetModal>
+    );
+  }
+);
+
+const styles = StyleSheet.create({
+  indicator: { backgroundColor: Colors.border, width: 36 },
+  sheetBg: { backgroundColor: Colors.surface },
+  scroll: { flex: 1 },
+  scrollContent: { paddingHorizontal: Spacing.xl, paddingTop: Spacing.sm, paddingBottom: 100 },
+  title: { fontSize: 17, fontWeight: '700', color: Colors.textPrimary },
+  subtitle: { fontSize: 12, color: Colors.textTertiary, marginTop: Spacing.xs, marginBottom: Spacing.lg },
+  footer: { backgroundColor: Colors.surface },
+  saveBtn: {
+    backgroundColor: Colors.primary, borderRadius: Radius.lg, paddingVertical: 16,
+    justifyContent: 'center', alignItems: 'center',
+    marginHorizontal: Spacing.xl, marginTop: Spacing.md, marginBottom: Spacing.md, ...Shadow.sm,
+  },
+  saveBtnDisabled: { backgroundColor: Colors.surfaceMuted },
+  saveBtnPressed: { backgroundColor: Colors.primaryDark },
+  saveText: { color: Colors.textInverse, fontSize: 16, fontWeight: '700' },
+  saveTextDisabled: { color: Colors.textTertiary },
+});

--- a/mobile/components/RangeCalendar.tsx
+++ b/mobile/components/RangeCalendar.tsx
@@ -1,0 +1,220 @@
+// mobile/components/RangeCalendar.tsx
+//
+// The month grid itself, with no opinion about whether it's collapsed behind a
+// trigger. DateRangePicker wraps it in a dropdown for the create screen;
+// EditDatesSheet shows it always-open in a bottom sheet.
+//
+// Deliberately built from plain RN views rather than a native date picker:
+// SplitEasy ships as a PWA as well as iOS/Android, and
+// @react-native-community/datetimepicker has no web build. Plain views render
+// identically on all three and pick up the app's theme tokens directly.
+import { useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  addMonths,
+  formatDayLabelWithYear,
+  formatMonthLabel,
+  monthGrid,
+  todayLocal,
+  yearMonthOf,
+  type YearMonth,
+} from '@/lib/date';
+import { Colors, Radius, Spacing } from '@/lib/theme';
+
+const WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+interface Props {
+  startDate: string | null;
+  endDate: string | null;
+  /** Emits a complete range, a start-only partial, or (null, null) when cleared. */
+  onChange: (startDate: string | null, endDate: string | null) => void;
+  /** Fired when a tap completes the range, so a wrapper can collapse or save. */
+  onRangeComplete?: () => void;
+  /**
+   * Bumping this resets the visible month back to the one holding the range —
+   * wrappers use it when they reappear, so the calendar doesn't stay parked on
+   * whatever month was last browsed to.
+   */
+  resetToken?: number;
+}
+
+export function RangeCalendar({
+  startDate,
+  endDate,
+  onChange,
+  onRangeComplete,
+  resetToken = 0,
+}: Props) {
+  const [visibleMonth, setVisibleMonth] = useState<YearMonth>(() => yearMonthOf(startDate));
+
+  useEffect(() => {
+    setVisibleMonth(yearMonthOf(startDate));
+    // Only on an explicit reset — tracking startDate here would yank the view
+    // back a month mid-selection, right after the first tap.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetToken]);
+
+  function handleDayPress(date: string) {
+    // A complete range, or a tap before the pending start, begins a new range.
+    // Anything else closes the pending one.
+    if (!startDate || endDate || date < startDate) {
+      onChange(date, null);
+      return;
+    }
+    onChange(startDate, date);
+    onRangeComplete?.();
+  }
+
+  const today = todayLocal();
+  const weeks = monthGrid(visibleMonth);
+
+  return (
+    <View>
+      <View style={styles.monthBar}>
+        <Pressable
+          onPress={() => setVisibleMonth((m) => addMonths(m, -1))}
+          style={styles.monthNav}
+          accessibilityRole="button"
+          accessibilityLabel="Previous month"
+        >
+          <Ionicons name="chevron-back" size={18} color={Colors.textPrimary} />
+        </Pressable>
+        <Text style={styles.monthLabel}>{formatMonthLabel(visibleMonth)}</Text>
+        <Pressable
+          onPress={() => setVisibleMonth((m) => addMonths(m, 1))}
+          style={styles.monthNav}
+          accessibilityRole="button"
+          accessibilityLabel="Next month"
+        >
+          <Ionicons name="chevron-forward" size={18} color={Colors.textPrimary} />
+        </Pressable>
+      </View>
+
+      <View style={styles.weekdayRow}>
+        {WEEKDAYS.map((d, i) => (
+          // Weekday initials repeat (S/T twice), so the index is the key.
+          <Text key={i} style={styles.weekday}>
+            {d}
+          </Text>
+        ))}
+      </View>
+
+      {weeks.map((week, wi) => (
+        <View key={wi} style={styles.week}>
+          {week.map((date, di) => {
+            // Leading/trailing padding still has to occupy its column, so it
+            // uses the flex cell rather than the day circle.
+            if (!date) return <View key={di} style={styles.dayCell} />;
+
+            const isStart = date === startDate;
+            const isEnd = date === endDate;
+            const inRange = !!startDate && !!endDate && date > startDate && date < endDate;
+            const isEdge = isStart || isEnd;
+
+            // The connecting band is a separate layer behind the day circle,
+            // spanning the full cell so it meets its neighbours edge to edge
+            // across the week. At the two ends it starts at the circle's centre
+            // rather than the cell edge — filling the whole end cell would read
+            // as half a day more range than was actually picked. A single-day
+            // trip gets no band at all.
+            const hasRange = !!startDate && !!endDate && startDate !== endDate;
+            let bandStyle = null;
+            if (inRange) bandStyle = styles.bandFull;
+            else if (hasRange && isStart) bandStyle = styles.bandFromCenter;
+            else if (hasRange && isEnd) bandStyle = styles.bandToCenter;
+
+            return (
+              <View key={di} style={styles.dayCell}>
+                {bandStyle && <View style={[styles.band, bandStyle]} />}
+                <Pressable
+                  style={[styles.day, isEdge && styles.dayEdge]}
+                  onPress={() => handleDayPress(date)}
+                  accessibilityRole="button"
+                  accessibilityLabel={formatDayLabelWithYear(date)}
+                  accessibilityState={{ selected: isEdge || inRange }}
+                >
+                  <Text
+                    style={[
+                      styles.dayText,
+                      date === today && !isEdge && styles.dayTextToday,
+                      isEdge && styles.dayTextEdge,
+                    ]}
+                  >
+                    {Number(date.slice(8, 10))}
+                  </Text>
+                </Pressable>
+              </View>
+            );
+          })}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+/** Shared by the picker's dropdown and the edit sheet, so both read the same. */
+export function RangeCalendarFooter({
+  startDate,
+  endDate,
+  onClear,
+}: {
+  startDate: string | null;
+  endDate: string | null;
+  onClear: () => void;
+}) {
+  const empty = !startDate && !endDate;
+  return (
+    <View style={styles.footer}>
+      <Text style={styles.hint} numberOfLines={1}>
+        {startDate && !endDate ? 'Now pick the end date' : 'Tap a start and end date'}
+      </Text>
+      <Pressable
+        onPress={onClear}
+        disabled={empty}
+        accessibilityRole="button"
+        accessibilityLabel="Clear dates"
+      >
+        <Text style={[styles.clear, empty && styles.clearDisabled]}>Clear</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  monthBar: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    marginBottom: Spacing.sm,
+  },
+  monthNav: { padding: Spacing.sm, borderRadius: Radius.sm },
+  monthLabel: { flex: 1, minWidth: 0, textAlign: 'center', fontSize: 15, fontWeight: '700', color: Colors.textPrimary },
+  weekdayRow: { flexDirection: 'row', marginBottom: Spacing.xs },
+  weekday: { flex: 1, textAlign: 'center', fontSize: 11, fontWeight: '600', color: Colors.textTertiary },
+  week: { flexDirection: 'row' },
+  // minWidth: 0 lets the seven columns share the row evenly on web instead of
+  // each refusing to shrink below its content width.
+  dayCell: { flex: 1, minWidth: 0, alignItems: 'center' },
+  band: { position: 'absolute', top: 0, bottom: 0, backgroundColor: Colors.primaryMuted },
+  bandFull: { left: 0, right: 0 },
+  bandFromCenter: { left: '50%', right: 0 },
+  bandToCenter: { left: 0, right: '50%' },
+  // Sized as a share of the column rather than a fixed 38px, which would
+  // overflow seven-across on a 320px-wide screen. aspectRatio keeps the
+  // selected-day background a circle at any width.
+  day: {
+    width: '100%', maxWidth: 40, aspectRatio: 1, borderRadius: Radius.full,
+    justifyContent: 'center', alignItems: 'center',
+  },
+  dayEdge: { backgroundColor: Colors.primary },
+  dayText: { fontSize: 14, color: Colors.textPrimary },
+  dayTextToday: { color: Colors.primary, fontWeight: '700' },
+  dayTextEdge: { color: Colors.textInverse, fontWeight: '700' },
+  footer: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    marginTop: Spacing.sm, paddingHorizontal: Spacing.sm, paddingTop: Spacing.sm,
+    borderTopWidth: 1, borderTopColor: Colors.divider,
+  },
+  hint: { flex: 1, minWidth: 0, fontSize: 12, color: Colors.textTertiary },
+  clear: { fontSize: 14, fontWeight: '600', color: Colors.primary, paddingLeft: Spacing.md },
+  clearDisabled: { color: Colors.textTertiary },
+});

--- a/mobile/lib/date.ts
+++ b/mobile/lib/date.ts
@@ -55,3 +55,65 @@ export function formatDayLabel(value: string): string {
     day: 'numeric',
   });
 }
+
+/** "Aug 6, 2026"-style label, used where the year matters. */
+export function formatDayLabelWithYear(value: string): string {
+  return parseLocalDate(value).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Month-grid helpers, for the calendar range picker.
+// `month` is 0-indexed throughout, matching Date's own convention.
+// ---------------------------------------------------------------------------
+
+export interface YearMonth {
+  year: number;
+  month: number;
+}
+
+/** The year/month `delta` months away from the given one. */
+export function addMonths({ year, month }: YearMonth, delta: number): YearMonth {
+  // Day 1 keeps this away from the end-of-month clamping that makes naive
+  // month arithmetic skip (Jan 31 + 1 month landing in March).
+  const d = new Date(year, month + delta, 1);
+  return { year: d.getFullYear(), month: d.getMonth() };
+}
+
+/** The year/month a stored date falls in, or the current one for null. */
+export function yearMonthOf(value: string | null): YearMonth {
+  const d = value ? parseLocalDate(value) : new Date();
+  return { year: d.getFullYear(), month: d.getMonth() };
+}
+
+/** "August 2026" heading for a month. */
+export function formatMonthLabel({ year, month }: YearMonth): string {
+  return new Date(year, month, 1).toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+/**
+ * A month laid out as calendar weeks, Sunday-first. Each cell is a
+ * "YYYY-MM-DD" date string, or null for the leading/trailing padding that
+ * keeps real days under the right weekday column.
+ */
+export function monthGrid({ year, month }: YearMonth): (string | null)[][] {
+  const firstWeekday = new Date(year, month, 1).getDay();
+  // Day 0 of the next month is the last day of this one.
+  const dayCount = new Date(year, month + 1, 0).getDate();
+
+  const cells: (string | null)[] = Array(firstWeekday).fill(null);
+  for (let day = 1; day <= dayCount; day++) {
+    cells.push(toLocalDateString(new Date(year, month, day)));
+  }
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const weeks: (string | null)[][] = [];
+  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
+  return weeks;
+}

--- a/mobile/lib/db.ts
+++ b/mobile/lib/db.ts
@@ -695,6 +695,33 @@ export async function endVacation(id: string): Promise<void> {
   );
 }
 
+export async function updateVacationDates(
+  id: string,
+  startDate: string | null,
+  endDate: string | null
+): Promise<void> {
+  const d = db();
+  if (startDate && endDate) {
+    // The same overlap rule createVacation applies, minus this vacation
+    // itself — every trip overlaps its own dates.
+    const conflicts = await d.getAllAsync(
+      `SELECT id FROM vacations
+       WHERE status IN ('draft','active')
+         AND id != ?
+         AND start_date IS NOT NULL AND end_date IS NOT NULL
+         AND start_date <= ? AND end_date >= ?`,
+      [id, endDate, startDate]
+    );
+    if (conflicts.length > 0) {
+      throw new VacationConflictError('overlap', 'Dates overlap an existing vacation.');
+    }
+  }
+  await d.runAsync(
+    `UPDATE vacations SET start_date = ?, end_date = ? WHERE id = ?`,
+    [startDate, endDate, id]
+  );
+}
+
 export async function deleteVacation(id: string): Promise<void> {
   await db().withTransactionAsync(async () => {
     await db().runAsync(

--- a/mobile/lib/db.web.ts
+++ b/mobile/lib/db.web.ts
@@ -616,6 +616,31 @@ export async function endVacation(id: string): Promise<void> {
   await done(tx);
 }
 
+export async function updateVacationDates(
+  id: string,
+  startDate: string | null,
+  endDate: string | null
+): Promise<void> {
+  if (startDate && endDate) {
+    // The same overlap rule createVacation applies, minus this vacation
+    // itself — every trip overlaps its own dates.
+    const all = await getVacations();
+    const conflict = all.some(
+      (v) =>
+        v.id !== id &&
+        (v.status === 'draft' || v.status === 'active') &&
+        v.start_date && v.end_date &&
+        rangesOverlap(v.start_date, v.end_date, startDate, endDate)
+    );
+    if (conflict) throw new VacationConflictError('overlap', 'Dates overlap an existing vacation.');
+  }
+  const tx = db().transaction(VACATION_STORE, 'readwrite');
+  const store = tx.objectStore(VACATION_STORE);
+  const existing = await req(store.get(id) as IDBRequest<Vacation | undefined>);
+  if (existing) store.put({ ...existing, start_date: startDate, end_date: endDate });
+  await done(tx);
+}
+
 export async function deleteVacation(id: string): Promise<void> {
   const tx = db().transaction([TX_STORE, VACATION_STORE], 'readwrite');
   const txStore = tx.objectStore(TX_STORE);

--- a/mobile/stores/vacationStore.ts
+++ b/mobile/stores/vacationStore.ts
@@ -6,6 +6,7 @@ import {
   startVacation as dbStartVacation,
   endVacation as dbEndVacation,
   deleteVacation as dbDeleteVacation,
+  updateVacationDates as dbUpdateVacationDates,
   reconcileVacationStatuses,
 } from '@/lib/db';
 import { Vacation, CreateVacationInput } from '@/lib/types';
@@ -20,6 +21,7 @@ interface VacationState {
   startVacation: (id: string) => Promise<void>;
   endVacation: (id: string) => Promise<void>;
   deleteVacation: (id: string) => Promise<void>;
+  updateDates: (id: string, startDate: string | null, endDate: string | null) => Promise<void>;
 }
 
 export const useVacationStore = create<VacationState>((set, get) => ({
@@ -60,5 +62,13 @@ export const useVacationStore = create<VacationState>((set, get) => ({
   deleteVacation: async (id) => {
     await dbDeleteVacation(id);
     await get().load();
+  },
+
+  updateDates: async (id, startDate, endDate) => {
+    await dbUpdateVacationDates(id, startDate, endDate);
+    // Reconcile rather than reload: the edited dates can make a draft due
+    // now, or push an active vacation's end into the past, and status has to
+    // follow the dates the same way it does on create.
+    await get().reconcile();
   },
 }));


### PR DESCRIPTION
Vacation dates were two free-text `YYYY-MM-DD` fields, which put both format and ordering on the user and needed a regex plus an error message to police it. This replaces them with an inline start→end range calendar.

Tapping a start then an end fills the range and collapses the panel, mirroring the Splitwise group dropdown directly below it on the same screen.

## Why a custom component

Built from plain RN views rather than a native picker on purpose: SplitEasy ships as a **PWA** alongside iOS/Android, and `@react-native-community/datetimepicker` has **no web build**. Plain views render identically on all three targets, add no dependency, and pick up the existing theme tokens directly.

`react-native-calendars` was the other candidate — rejected as a ~1MB dependency whose own theming layer would need bridging to `lib/theme.ts` for what is one screen.

## Validation gets simpler

The calendar can only ever emit an ordered range, so `DATE_RE` and the `start <= end` check are gone. The one reachable invalid state left is a **half-picked range** — a start with no end — which now blocks saving and explains itself inline, instead of silently persisting a start date that `reconcileVacationStatuses` would treat as an open-ended vacation.

## Layout details

- Day cells are sized as a share of their column rather than a fixed 38px, which would have overflowed seven-across at 320px.
- The connecting band is a layer *behind* the day circles, so it meets its neighbours edge to edge across a week boundary.
- The band starts at the end circles' **centres**, not their cell edges — filling the whole end cell reads as half a day more range than was actually picked.

## Verification

Checked in the browser at a 320px root, since the last two bugs on this screen were layout issues unit tests couldn't catch:

- **0 elements overflow** the viewport; all seven columns fit.
- Grid alignment confirmed against known months — Aug 1 2026 lands in the Saturday column, Feb 2024 shows 29 days.
- Range band, week-boundary wrap, today marker, and collapse-on-complete all render correctly.

The `blocks saving until the end date is chosen` test was confirmed to fail when the guard is removed.

- `npx tsc --noEmit` — clean
- `npx jest` — **267 passed, 27 suites** (7 new picker tests, 3 new screen tests)

## Note

Month-grid helpers were added to `lib/date.ts` and build every cell through the local-time helpers, so the calendar agrees with the device date the reconciler keys off after #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4yNBGWGvDeJhEj2V4N1j1