### PR TITLE
fix: don't render routes before the database has opened

### DIFF
--- a/mobile/__tests__/app/root-layout.test.tsx
+++ b/mobile/__tests__/app/root-layout.test.tsx
@@ -1,0 +1,77 @@
+// mobile/__tests__/app/root-layout.test.tsx
+jest.mock('expo-router', () => ({
+  // A stand-in for whatever route is being rendered, so the test can assert
+  // whether children mounted at all.
+  Slot: () => {
+    const { Text } = require('react-native');
+    return <Text>ROUTE CONTENT</Text>;
+  },
+  SplashScreen: { preventAutoHideAsync: jest.fn(), hideAsync: jest.fn() },
+}));
+jest.mock('@gorhom/bottom-sheet', () => ({
+  BottomSheetModalProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+// GestureHandlerRootView reaches for the native module on mount, which is not
+// installed in the jest-expo environment.
+jest.mock('react-native-gesture-handler', () => ({
+  GestureHandlerRootView: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/lib/db', () => ({ initDb: jest.fn() }));
+jest.mock('@/stores/authStore', () => ({ useAuthStore: jest.fn() }));
+jest.mock('@/stores/plaidStore', () => ({ usePlaidStore: jest.fn() }));
+
+import { render, screen, waitFor, act } from '@testing-library/react-native';
+import RootLayout from '@/app/_layout';
+import { initDb } from '@/lib/db';
+import { useAuthStore } from '@/stores/authStore';
+import { usePlaidStore } from '@/stores/plaidStore';
+
+const mockInitDb = initDb as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  (useAuthStore as unknown as jest.Mock).mockReturnValue({ hydrate: jest.fn().mockResolvedValue(undefined) });
+  (usePlaidStore as unknown as jest.Mock).mockReturnValue({ hydrate: jest.fn().mockResolvedValue(undefined) });
+});
+
+afterEach(() => {
+  (console.error as jest.Mock).mockRestore();
+});
+
+test('no route renders until the database has opened', async () => {
+  // Held open, standing in for the real async open.
+  let resolveInit: () => void = () => {};
+  mockInitDb.mockReturnValue(new Promise<void>((res) => { resolveInit = res; }));
+
+  render(<RootLayout />);
+
+  // The regression: routes query the DB from their mount effects, so a route
+  // that mounts in this window throws "DB not initialized" and renders empty.
+  // That is what a deep link or a browser refresh does.
+  expect(screen.queryByText('ROUTE CONTENT')).toBeNull();
+  expect(screen.getByLabelText('SplitEasy startup')).toBeTruthy();
+
+  await act(async () => { resolveInit(); });
+
+  expect(screen.getByText('ROUTE CONTENT')).toBeTruthy();
+});
+
+test('a database that fails to open still lets the app render', async () => {
+  mockInitDb.mockRejectedValue(new Error('quota exceeded'));
+
+  render(<RootLayout />);
+
+  // Gating on "settled" rather than "succeeded" — otherwise a failed open
+  // strands the user on the startup screen with no way forward.
+  await waitFor(() => expect(screen.getByText('ROUTE CONTENT')).toBeTruthy());
+});
+
+test('the database is opened exactly once', async () => {
+  mockInitDb.mockResolvedValue(undefined);
+
+  render(<RootLayout />);
+
+  await waitFor(() => expect(screen.getByText('ROUTE CONTENT')).toBeTruthy());
+  expect(mockInitDb).toHaveBeenCalledTimes(1);
+});

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -2,9 +2,10 @@
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { Slot, SplashScreen } from 'expo-router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { StartupScreen } from '@/components/StartupScreen';
 import { ToastProvider } from '@/components/ToastProvider';
 import { useAuthStore } from '@/stores/authStore';
 import { usePlaidStore } from '@/stores/plaidStore';
@@ -17,6 +18,7 @@ if (Platform.OS !== 'web') {
 export default function RootLayout() {
   const { hydrate: hydrateAuth } = useAuthStore();
   const { hydrate: hydratePlaid } = usePlaidStore();
+  const [dbSettled, setDbSettled] = useState(false);
 
   useEffect(() => {
     async function init() {
@@ -25,6 +27,10 @@ export default function RootLayout() {
       } catch (e) {
         console.error('initDb failed', e);
       }
+      // Settled, not succeeded: a database that failed to open must not
+      // strand the user on the startup screen forever. Screens surface their
+      // own load errors from there.
+      setDbSettled(true);
       await Promise.all([hydrateAuth(), hydratePlaid()]);
     }
     void init();
@@ -52,7 +58,12 @@ export default function RootLayout() {
       <SafeAreaProvider>
         <ToastProvider>
           <BottomSheetModalProvider>
-            <Slot />
+            {/* Nothing may render until the database has been opened. Routes
+                query it from mount effects, so a route rendered in the same
+                tick as this layout — which is what a deep link or a browser
+                refresh does — would otherwise throw "DB not initialized" and
+                leave the screen empty until something re-focused it. */}
+            {dbSettled ? <Slot /> : <StartupScreen status="Opening your data…" />}
           </BottomSheetModalProvider>
         </ToastProvider>
       </SafeAreaProvider>

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,7 +1,7 @@
 import { SplashScreen, useRouter } from 'expo-router';
-import Constants from 'expo-constants';
 import { useEffect, useLayoutEffect, useRef } from 'react';
-import { ActivityIndicator, Platform, StyleSheet, Text, View } from 'react-native';
+import { Platform } from 'react-native';
+import { StartupScreen } from '@/components/StartupScreen';
 import { useAuthStore } from '@/stores/authStore';
 import { usePlaidStore } from '@/stores/plaidStore';
 
@@ -36,52 +36,5 @@ export default function Index() {
       ? 'Restoring bank link…'
       : 'Opening…';
 
-  return (
-    <View style={styles.screen} accessibilityLabel="SplitEasy startup">
-      <Text style={styles.wordmark}>SplitEasy</Text>
-      <Text style={styles.tagline}>Expense splits, simplified</Text>
-      <ActivityIndicator size="large" color="#fff" style={styles.spinner} />
-      <Text style={styles.status}>{statusLabel}</Text>
-      <Text style={styles.debug}>
-        JS bundle OK · v{Constants.expoConfig?.version ?? '1.0.0'}
-      </Text>
-    </View>
-  );
+  return <StartupScreen status={statusLabel} />;
 }
-
-const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: '#5C7AEA',
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 32,
-  },
-  wordmark: {
-    fontSize: 40,
-    fontWeight: '800',
-    color: '#fff',
-    letterSpacing: -0.5,
-  },
-  tagline: {
-    marginTop: 8,
-    fontSize: 16,
-    color: 'rgba(255,255,255,0.92)',
-    textAlign: 'center',
-  },
-  spinner: {
-    marginTop: 36,
-  },
-  status: {
-    marginTop: 20,
-    fontSize: 15,
-    fontWeight: '600',
-    color: 'rgba(255,255,255,0.95)',
-  },
-  debug: {
-    position: 'absolute',
-    bottom: 48,
-    fontSize: 12,
-    color: 'rgba(255,255,255,0.75)',
-  },
-});

--- a/mobile/components/StartupScreen.tsx
+++ b/mobile/components/StartupScreen.tsx
@@ -1,0 +1,57 @@
+// mobile/components/StartupScreen.tsx
+// The pre-app screen, shared by the root layout (while the database opens) and
+// app/index.tsx (while auth and Plaid state rehydrate), so the two stages look
+// like one continuous startup rather than two different screens.
+import Constants from 'expo-constants';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+
+export function StartupScreen({ status }: { status: string }) {
+  return (
+    <View style={styles.screen} accessibilityLabel="SplitEasy startup">
+      <Text style={styles.wordmark}>SplitEasy</Text>
+      <Text style={styles.tagline}>Expense splits, simplified</Text>
+      <ActivityIndicator size="large" color="#fff" style={styles.spinner} />
+      <Text style={styles.status}>{status}</Text>
+      <Text style={styles.debug}>
+        JS bundle OK · v{Constants.expoConfig?.version ?? '1.0.0'}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#5C7AEA',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+  },
+  wordmark: {
+    fontSize: 40,
+    fontWeight: '800',
+    color: '#fff',
+    letterSpacing: -0.5,
+  },
+  tagline: {
+    marginTop: 8,
+    fontSize: 16,
+    color: 'rgba(255,255,255,0.92)',
+    textAlign: 'center',
+  },
+  spinner: {
+    marginTop: 36,
+  },
+  status: {
+    marginTop: 20,
+    fontSize: 15,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.95)',
+  },
+  debug: {
+    position: 'absolute',
+    bottom: 48,
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.75)',
+  },
+});


### PR DESCRIPTION
## The bug

Deep-linking or refreshing the browser on any data-backed route rendered an **empty screen**.

`app/_layout.tsx` kicked off `initDb()` in an effect and rendered `<Slot />` in the same pass, so the route mounted while `_db` was still `null` and its `useFocusEffect` threw:

```
Error: DB not initialized — call initDb() first
    at db (lib/db.web.ts:40)
    at getVacations (lib/db.web.ts:585)
    at load (stores/vacationStore.ts:34)
    at useFocusEffect$argument_0 (app/vacation/[id].tsx:59)
```

Nothing retried, so the screen stayed empty until something happened to re-focus it.

## Why it went unnoticed

A normal cold start lands on `index.tsx`, which holds the user on the startup screen through the auth redirect. By the time a data screen mounts, `initDb()` has long since resolved.

Only entering **directly** at a route skips that delay — which is exactly what a PWA user does when they bookmark a page or hit refresh. I hit it while verifying #66.

## The fix

Hold `<Slot />` until `initDb()` settles. One gate fixes every route at once, including ones added later, rather than teaching each screen to retry a query it shouldn't have made yet.

Two details worth noting:

- **Gate on *settled*, not *succeeded*.** A database that fails to open must not strand the user on the startup screen with no way forward — screens surface their own load errors from there. There's a test for this.
- **`StartupScreen` is extracted from `index.tsx`** so the wait shows the existing startup visual rather than a blank frame, and so the database and auth/Plaid stages read as one continuous startup instead of two different screens. `index.tsx` renders it with its own status label, so its behaviour is unchanged.

## Verification

Reproduced and fixed against the real failing case in the PWA — a cold hard load of `/vacation/<id>`:

- **Before:** `Uncaught Error: DB not initialized` on every load, screen empty
- **After:** the vacation renders, console clean across repeated hard reloads

The gate test was confirmed to fail against the old ungated render:

```
✕ no route renders until the database has opened
```

- `npx tsc --noEmit` — clean
- `npx jest` — **260 passed, 27 suites** (3 new)

## Note

Independent of #66 and branched off `main`, so the two can merge in either order. The dates on the screenshot above render as raw ISO here because the friendlier formatting lives on #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4yNBGWGvDeJhEj2V4N1j1