### PR TITLE
fix: restore rendering — open the database lazily instead of gating Slot

### DIFF
--- a/mobile/__tests__/app/root-layout.test.tsx
+++ b/mobile/__tests__/app/root-layout.test.tsx
@@ -1,9 +1,18 @@
-// mobile/__tests__/app/root-layout.test.tsx
+// mobile/app/_layout.tsx must render <Slot /> on its very first render:
+// expo-router registers the root navigator there, and deferring it makes the
+// first router.replace() throw "Attempted to navigate before mounting the Root
+// Layout component" — which blanks the whole app, not just one route.
+// Tracked on globalThis because a jest.mock factory may not close over
+// module-scope variables.
+type Probe = { rootRenders: number; slotFirstRender: boolean | null };
+const probe = () => (globalThis as unknown as { __probe: Probe }).__probe;
+(globalThis as unknown as { __probe: Probe }).__probe = { rootRenders: 0, slotFirstRender: null };
+
 jest.mock('expo-router', () => ({
-  // A stand-in for whatever route is being rendered, so the test can assert
-  // whether children mounted at all.
   Slot: () => {
     const { Text } = require('react-native');
+    const p = (globalThis as unknown as { __probe: Probe }).__probe;
+    if (p.slotFirstRender === null) p.slotFirstRender = p.rootRenders === 1;
     return <Text>ROUTE CONTENT</Text>;
   },
   SplashScreen: { preventAutoHideAsync: jest.fn(), hideAsync: jest.fn() },
@@ -20,7 +29,7 @@ jest.mock('@/lib/db', () => ({ initDb: jest.fn() }));
 jest.mock('@/stores/authStore', () => ({ useAuthStore: jest.fn() }));
 jest.mock('@/stores/plaidStore', () => ({ usePlaidStore: jest.fn() }));
 
-import { render, screen, waitFor, act } from '@testing-library/react-native';
+import { render, screen, waitFor } from '@testing-library/react-native';
 import RootLayout from '@/app/_layout';
 import { initDb } from '@/lib/db';
 import { useAuthStore } from '@/stores/authStore';
@@ -28,9 +37,18 @@ import { usePlaidStore } from '@/stores/plaidStore';
 
 const mockInitDb = initDb as jest.Mock;
 
+// Counting root renders from the outside, so the Slot mock can tell whether it
+// was reached on render #1.
+function Counted() {
+  probe().rootRenders += 1;
+  return <RootLayout />;
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   jest.spyOn(console, 'error').mockImplementation(() => {});
+  probe().rootRenders = 0;
+  probe().slotFirstRender = null;
   (useAuthStore as unknown as jest.Mock).mockReturnValue({ hydrate: jest.fn().mockResolvedValue(undefined) });
   (usePlaidStore as unknown as jest.Mock).mockReturnValue({ hydrate: jest.fn().mockResolvedValue(undefined) });
 });
@@ -39,39 +57,31 @@ afterEach(() => {
   (console.error as jest.Mock).mockRestore();
 });
 
-test('no route renders until the database has opened', async () => {
-  // Held open, standing in for the real async open.
-  let resolveInit: () => void = () => {};
-  mockInitDb.mockReturnValue(new Promise<void>((res) => { resolveInit = res; }));
+test('Slot renders on the first render, before the database has opened', () => {
+  // Held open: the database is still opening while the tree first renders.
+  mockInitDb.mockReturnValue(new Promise<void>(() => {}));
 
-  render(<RootLayout />);
+  render(<Counted />);
 
-  // The regression: routes query the DB from their mount effects, so a route
-  // that mounts in this window throws "DB not initialized" and renders empty.
-  // That is what a deep link or a browser refresh does.
-  expect(screen.queryByText('ROUTE CONTENT')).toBeNull();
-  expect(screen.getByLabelText('SplitEasy startup')).toBeTruthy();
-
-  await act(async () => { resolveInit(); });
-
+  expect(probe().slotFirstRender).toBe(true);
   expect(screen.getByText('ROUTE CONTENT')).toBeTruthy();
 });
 
-test('a database that fails to open still lets the app render', async () => {
+test('Slot still renders when the database fails to open', async () => {
   mockInitDb.mockRejectedValue(new Error('quota exceeded'));
 
-  render(<RootLayout />);
+  render(<Counted />);
 
-  // Gating on "settled" rather than "succeeded" — otherwise a failed open
-  // strands the user on the startup screen with no way forward.
-  await waitFor(() => expect(screen.getByText('ROUTE CONTENT')).toBeTruthy());
+  expect(screen.getByText('ROUTE CONTENT')).toBeTruthy();
+  await waitFor(() => expect(console.error).toHaveBeenCalled());
+  // Still mounted after the rejection is handled.
+  expect(screen.getByText('ROUTE CONTENT')).toBeTruthy();
 });
 
-test('the database is opened exactly once', async () => {
+test('the database warm-up runs once', async () => {
   mockInitDb.mockResolvedValue(undefined);
 
-  render(<RootLayout />);
+  render(<Counted />);
 
-  await waitFor(() => expect(screen.getByText('ROUTE CONTENT')).toBeTruthy());
-  expect(mockInitDb).toHaveBeenCalledTimes(1);
+  await waitFor(() => expect(mockInitDb).toHaveBeenCalledTimes(1));
 });

--- a/mobile/__tests__/lib/db.test.ts
+++ b/mobile/__tests__/lib/db.test.ts
@@ -31,6 +31,7 @@ import {
   removeTransactionFromVacation,
   reconcileVacationStatuses,
   updateVacationDates,
+  resetDbForTests,
   rekeyTransaction,
   markTransactionsReversed,
   getReviewTransactions,
@@ -51,6 +52,7 @@ const mockDb = {
 beforeEach(() => {
   jest.clearAllMocks();
   (SQLite.openDatabaseAsync as jest.Mock).mockResolvedValue(mockDb);
+  resetDbForTests();
 });
 
 test('initDb opens database and runs migrations', async () => {

--- a/mobile/__tests__/lib/db.web.test.ts
+++ b/mobile/__tests__/lib/db.web.test.ts
@@ -8,7 +8,7 @@ import {
   persistCombinedSplit, revertCombinedSplit,
   createVacation, getVacations, getVacation, getActiveVacation, startVacation, endVacation, deleteVacation,
   getVacationPendingTransactions, getVacationHistory, assignTransactionsToVacation,
-  removeTransactionFromVacation, reconcileVacationStatuses, updateVacationDates,
+  removeTransactionFromVacation, reconcileVacationStatuses, updateVacationDates, resetDbForTests,
   rekeyTransaction, markTransactionsReversed, getReviewTransactions, clearReview,
 } from '@/lib/db.web';
 import { PlaidTransaction, SplitDecision } from '@/lib/types';
@@ -57,9 +57,53 @@ async function seedRaw(store: string, value: object) {
   d.close();
 }
 
+describe('opening the database', () => {
+  beforeEach(() => {
+    (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+    resetDbForTests(); // drop the handle onto the previous factory
+  });
+
+  it('a query with no prior initDb() opens the database instead of throwing', async () => {
+    // The deep-link/refresh bug: React runs effects child-first, so a route's
+    // mount effect queries before the root layout's effect has opened the
+    // database. This used to throw "DB not initialized — call initDb() first"
+    // and leave the screen blank.
+    await expect(getNewTransactions()).resolves.toEqual([]);
+  });
+
+  it('concurrent first callers share a single open', async () => {
+    const spy = jest.spyOn(indexedDB, 'open');
+    await Promise.all([getNewTransactions(), getVacations(), getHistoryTransactions()]);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it('initDb is idempotent and does not reopen an already-open database', async () => {
+    await initDb();
+    const spy = jest.spyOn(indexedDB, 'open');
+    await initDb();
+    await initDb();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('a failed open is retried rather than cached forever', async () => {
+    const real = indexedDB.open.bind(indexedDB);
+    const spy = jest.spyOn(indexedDB, 'open').mockImplementationOnce(() => {
+      throw new Error('quota exceeded');
+    });
+    await expect(getNewTransactions()).rejects.toThrow('quota exceeded');
+    spy.mockImplementation(real);
+    // A transient failure must not poison every later query.
+    await expect(getNewTransactions()).resolves.toEqual([]);
+    spy.mockRestore();
+  });
+});
+
 describe('db.web (IndexedDB)', () => {
   beforeEach(async () => {
     (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory(); // fresh DB per test
+    resetDbForTests(); // drop the handle onto the previous factory
     await initDb();
   });
 
@@ -223,6 +267,7 @@ describe('db.web (IndexedDB)', () => {
 describe('rekeyTransaction (IndexedDB)', () => {
   beforeEach(async () => {
     (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+    resetDbForTests(); // drop the handle onto the previous factory
     await initDb();
   });
 
@@ -327,6 +372,7 @@ describe('rekeyTransaction (IndexedDB)', () => {
 describe('markTransactionsReversed (IndexedDB)', () => {
   beforeEach(async () => {
     (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+    resetDbForTests(); // drop the handle onto the previous factory
     await initDb();
   });
 
@@ -363,6 +409,7 @@ describe('markTransactionsReversed (IndexedDB)', () => {
 describe('getReviewTransactions / clearReview (IndexedDB)', () => {
   beforeEach(async () => {
     (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+    resetDbForTests(); // drop the handle onto the previous factory
     await initDb();
   });
 
@@ -445,6 +492,7 @@ describe('getReviewTransactions / clearReview (IndexedDB)', () => {
 describe('vacation CRUD (IndexedDB)', () => {
   beforeEach(async () => {
     (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory(); // fresh DB per test
+    resetDbForTests(); // drop the handle onto the previous factory
     await initDb();
   });
 
@@ -512,6 +560,7 @@ describe('vacation CRUD (IndexedDB)', () => {
 describe('vacation transaction capture & history (IndexedDB)', () => {
   beforeEach(async () => {
     (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory(); // fresh DB per test
+    resetDbForTests(); // drop the handle onto the previous factory
     await initDb();
   });
 

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -2,10 +2,9 @@
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { Slot, SplashScreen } from 'expo-router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { StartupScreen } from '@/components/StartupScreen';
 import { ToastProvider } from '@/components/ToastProvider';
 import { useAuthStore } from '@/stores/authStore';
 import { usePlaidStore } from '@/stores/plaidStore';
@@ -18,19 +17,16 @@ if (Platform.OS !== 'web') {
 export default function RootLayout() {
   const { hydrate: hydrateAuth } = useAuthStore();
   const { hydrate: hydratePlaid } = usePlaidStore();
-  const [dbSettled, setDbSettled] = useState(false);
 
   useEffect(() => {
     async function init() {
       try {
+        // Only a warm-up: lib/db opens on first use, so screens that query
+        // before this resolves await the same open rather than failing.
         await initDb();
       } catch (e) {
         console.error('initDb failed', e);
       }
-      // Settled, not succeeded: a database that failed to open must not
-      // strand the user on the startup screen forever. Screens surface their
-      // own load errors from there.
-      setDbSettled(true);
       await Promise.all([hydrateAuth(), hydratePlaid()]);
     }
     void init();
@@ -58,12 +54,12 @@ export default function RootLayout() {
       <SafeAreaProvider>
         <ToastProvider>
           <BottomSheetModalProvider>
-            {/* Nothing may render until the database has been opened. Routes
-                query it from mount effects, so a route rendered in the same
-                tick as this layout — which is what a deep link or a browser
-                refresh does — would otherwise throw "DB not initialized" and
-                leave the screen empty until something re-focused it. */}
-            {dbSettled ? <Slot /> : <StartupScreen status="Opening your data…" />}
+            {/* Slot must render on the very first render — expo-router
+                registers the root navigator here, and anything that defers it
+                makes the first router.replace() throw "Attempted to navigate
+                before mounting the Root Layout component". Waiting for the
+                database happens in lib/db instead, which opens on first use. */}
+            <Slot />
           </BottomSheetModalProvider>
         </ToastProvider>
       </SafeAreaProvider>

--- a/mobile/lib/db.ts
+++ b/mobile/lib/db.ts
@@ -7,19 +7,50 @@ import { todayLocal } from '@/lib/date';
 import { VacationConflictError } from '@/lib/vacationErrors';
 
 let _db: SQLite.SQLiteDatabase | null = null;
+let _opening: Promise<SQLite.SQLiteDatabase> | null = null;
 
-function db(): SQLite.SQLiteDatabase {
-  if (!_db) throw new Error('DB not initialized — call initDb() first');
+/**
+ * The open database, opening it on first use.
+ *
+ * Callers must not have to sequence themselves behind initDb(). React runs
+ * effects child-first, so a route's mount effect queries the database *before*
+ * the root layout's effect has had a chance to open it — the module owns its
+ * own readiness instead. Concurrent callers share one in-flight open.
+ */
+async function dbReady(): Promise<SQLite.SQLiteDatabase> {
+  if (_db) return _db;
+  if (!_opening) {
+    // Cleared on failure so a later call can retry rather than replaying a
+    // rejected promise forever.
+    _opening = openDatabase().catch((e) => {
+      _opening = null;
+      throw e;
+    });
+  }
+  _db = await _opening;
   return _db;
 }
 
+/** Opens (and migrates) the database. Idempotent — safe to call repeatedly. */
 export async function initDb(): Promise<void> {
-  _db = await SQLite.openDatabaseAsync('spliteasy.db');
-  await _db.execAsync('PRAGMA journal_mode = WAL;');
-  const row = await _db.getFirstAsync<{ user_version: number }>('PRAGMA user_version');
+  await dbReady();
+}
+
+/** Drops the cached handle so the next call reopens. Tests only. */
+export function resetDbForTests(): void {
+  _db = null;
+  _opening = null;
+}
+
+// The handle is local until every migration has run, so a concurrent caller
+// awaiting dbReady() can never be handed a half-migrated database.
+async function openDatabase(): Promise<SQLite.SQLiteDatabase> {
+  const d = await SQLite.openDatabaseAsync('spliteasy.db');
+  await d.execAsync('PRAGMA journal_mode = WAL;');
+  const row = await d.getFirstAsync<{ user_version: number }>('PRAGMA user_version');
   const version = row?.user_version ?? 0;
   if (version < 1) {
-    await _db.execAsync(`
+    await d.execAsync(`
       CREATE TABLE IF NOT EXISTS transactions (
         id TEXT PRIMARY KEY,
         merchant_name TEXT,
@@ -43,13 +74,13 @@ export async function initDb(): Promise<void> {
     `);
   }
   if (version >= 1 && version < 2) {
-    await _db.execAsync(`ALTER TABLE transactions ADD COLUMN pending INTEGER DEFAULT 0;`);
+    await d.execAsync(`ALTER TABLE transactions ADD COLUMN pending INTEGER DEFAULT 0;`);
   }
   if (version >= 1 && version < 3) {
-    await _db.execAsync(`ALTER TABLE split_decisions ADD COLUMN description TEXT;`);
+    await d.execAsync(`ALTER TABLE split_decisions ADD COLUMN description TEXT;`);
   }
   if (version < 4) {
-    await _db.execAsync(`
+    await d.execAsync(`
       CREATE TABLE IF NOT EXISTS vacations (
         id TEXT PRIMARY KEY,
         name TEXT,
@@ -71,25 +102,26 @@ export async function initDb(): Promise<void> {
     // adds vacation_id to the base CREATE TABLE, this ALTER must move behind
     // a `version >= 1` guard or it will fail with "duplicate column name" on
     // fresh installs.
-    await _db.execAsync(`ALTER TABLE transactions ADD COLUMN vacation_id TEXT REFERENCES vacations(id);`);
+    await d.execAsync(`ALTER TABLE transactions ADD COLUMN vacation_id TEXT REFERENCES vacations(id);`);
   }
   if (version < 5) {
     // Same rationale as vacation_id above: review_reason/amount_changed_from
     // are not in the base `version < 1` CREATE TABLE, so these ALTERs must
     // run ungated so a fresh install (version 0) gets the columns too.
-    await _db.execAsync(`ALTER TABLE transactions ADD COLUMN review_reason TEXT;`);
-    await _db.execAsync(`ALTER TABLE transactions ADD COLUMN amount_changed_from REAL;`);
+    await d.execAsync(`ALTER TABLE transactions ADD COLUMN review_reason TEXT;`);
+    await d.execAsync(`ALTER TABLE transactions ADD COLUMN amount_changed_from REAL;`);
   }
   // Only stamp when a migration actually ran, to avoid a file-header write on
   // every cold start. Keep the literal in sync with the highest block above:
   // when adding a `version < N` block, bump this to N.
   if (version < 5) {
-    await _db.execAsync(`PRAGMA user_version = 5;`);
+    await d.execAsync(`PRAGMA user_version = 5;`);
   }
+  return d;
 }
 
 export async function getNewTransactions(): Promise<Transaction[]> {
-  const rows = await db().getAllAsync<Omit<Transaction, 'pending'> & { pending: number }>(
+  const rows = await (await dbReady()).getAllAsync<Omit<Transaction, 'pending'> & { pending: number }>(
     `SELECT * FROM transactions WHERE status = 'new' AND vacation_id IS NULL ORDER BY date DESC`,
     []
   );
@@ -99,7 +131,7 @@ export async function getNewTransactions(): Promise<Transaction[]> {
 export async function getTransactionsByIds(ids: string[]): Promise<Transaction[]> {
   if (ids.length === 0) return [];
   const placeholders = ids.map(() => '?').join(',');
-  const rows = await db().getAllAsync<Omit<Transaction, 'pending'> & { pending: number }>(
+  const rows = await (await dbReady()).getAllAsync<Omit<Transaction, 'pending'> & { pending: number }>(
     `SELECT * FROM transactions WHERE id IN (${placeholders})`,
     ids
   );
@@ -169,7 +201,7 @@ function groupHistoryRows(rows: HistoryRow[]): HistoryItem[] {
 }
 
 export async function getHistoryTransactions(): Promise<HistoryItem[]> {
-  const rows = await db().getAllAsync<HistoryRow>(
+  const rows = await (await dbReady()).getAllAsync<HistoryRow>(
     `SELECT t.*, s.splitwise_expense_id, s.description, s.friend_names, s.amount_each
      FROM transactions t
      LEFT JOIN split_decisions s ON s.transaction_id = t.id
@@ -239,7 +271,7 @@ function groupReviewRows(rows: ReviewRow[]): ReviewItem[] {
 }
 
 export async function getReviewTransactions(): Promise<ReviewItem[]> {
-  const rows = await db().getAllAsync<ReviewRow>(
+  const rows = await (await dbReady()).getAllAsync<ReviewRow>(
     `SELECT t.*, s.splitwise_expense_id, s.friend_names, s.amount_each
      FROM transactions t
      LEFT JOIN split_decisions s ON s.transaction_id = t.id
@@ -253,14 +285,14 @@ export async function getReviewTransactions(): Promise<ReviewItem[]> {
 export async function clearReview(transactionIds: string[]): Promise<void> {
   if (transactionIds.length === 0) return;
   const placeholders = transactionIds.map(() => '?').join(',');
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `UPDATE transactions SET review_reason = NULL, amount_changed_from = NULL WHERE id IN (${placeholders})`,
     transactionIds
   );
 }
 
 export async function getVacationPendingTransactions(vacationId: string): Promise<Transaction[]> {
-  const rows = await db().getAllAsync<Omit<Transaction, 'pending'> & { pending: number }>(
+  const rows = await (await dbReady()).getAllAsync<Omit<Transaction, 'pending'> & { pending: number }>(
     `SELECT * FROM transactions WHERE status = 'new' AND vacation_id = ? ORDER BY date DESC`,
     [vacationId]
   );
@@ -268,7 +300,7 @@ export async function getVacationPendingTransactions(vacationId: string): Promis
 }
 
 export async function getVacationHistory(vacationId: string): Promise<HistoryItem[]> {
-  const rows = await db().getAllAsync<HistoryRow>(
+  const rows = await (await dbReady()).getAllAsync<HistoryRow>(
     `SELECT t.*, s.splitwise_expense_id, s.description, s.friend_names, s.amount_each
      FROM transactions t
      LEFT JOIN split_decisions s ON s.transaction_id = t.id
@@ -282,14 +314,14 @@ export async function getVacationHistory(vacationId: string): Promise<HistoryIte
 export async function assignTransactionsToVacation(vacationId: string, transactionIds: string[]): Promise<void> {
   if (transactionIds.length === 0) return;
   const placeholders = transactionIds.map(() => '?').join(',');
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `UPDATE transactions SET vacation_id = ? WHERE id IN (${placeholders}) AND status = 'new' AND vacation_id IS NULL`,
     [vacationId, ...transactionIds]
   );
 }
 
 export async function removeTransactionFromVacation(transactionId: string): Promise<void> {
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `UPDATE transactions SET vacation_id = NULL WHERE id = ? AND status = 'new'`,
     [transactionId]
   );
@@ -301,11 +333,11 @@ export async function reconcileVacationStatuses(): Promise<void> {
   // instant and stays UTC.
   const today = todayLocal();
   const now = new Date().toISOString();
-  await db().withTransactionAsync(async () => {
+  await (await dbReady()).withTransactionAsync(async () => {
     // 1. A draft whose entire window has already elapsed (past start AND
     //    past end) goes straight to 'ended' — it never needs the single
     //    active slot at all.
-    await db().runAsync(
+    await (await dbReady()).runAsync(
       `UPDATE vacations SET status = 'ended', ended_at = ?
        WHERE status = 'draft' AND start_date IS NOT NULL AND start_date <= ?
          AND end_date IS NOT NULL AND end_date < ?`,
@@ -316,7 +348,7 @@ export async function reconcileVacationStatuses(): Promise<void> {
     //    between two dated vacations (e.g. A ends 08-10, B starts 08-11)
     //    frees the active slot within this same reconcile call instead of
     //    stranding B in 'draft' for one extra cycle.
-    await db().runAsync(
+    await (await dbReady()).runAsync(
       `UPDATE vacations SET status = 'ended', ended_at = ?
        WHERE status = 'active' AND end_date IS NOT NULL AND end_date < ?`,
       [now, today]
@@ -331,7 +363,7 @@ export async function reconcileVacationStatuses(): Promise<void> {
     //    consideration here, and phase 2 already ended any expired active
     //    vacation, so this statement's NOT EXISTS check sees an up-to-date
     //    picture within this same transaction.
-    await db().runAsync(
+    await (await dbReady()).runAsync(
       `UPDATE vacations SET status = 'active', started_at = ?
        WHERE status = 'draft' AND start_date IS NOT NULL AND start_date <= ?
          AND NOT EXISTS (SELECT 1 FROM vacations v2 WHERE v2.status = 'active')
@@ -346,7 +378,7 @@ export async function reconcileVacationStatuses(): Promise<void> {
 }
 
 export async function upsertTransactions(txs: PlaidTransaction[], activeVacationId: string | null = null): Promise<void> {
-  const d = db();
+  const d = await dbReady();
   const now = new Date().toISOString();
   for (const tx of txs) {
     const name = tx.merchant_name ?? tx.name;
@@ -373,18 +405,18 @@ export async function deleteTransactionsByPlaidIds(ids: string[]): Promise<void>
   // Native never enables `PRAGMA foreign_keys`, so the ON DELETE CASCADE on
   // split_decisions.transaction_id is inert — delete explicitly, mirroring
   // db.web.ts's explicit DECISION_STORE delete.
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `DELETE FROM split_decisions WHERE transaction_id IN (${placeholders})`,
     ids
   );
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `DELETE FROM transactions WHERE id IN (${placeholders})`,
     ids
   );
 }
 
 export async function updateTransactionStatus(id: string, status: TransactionStatus): Promise<void> {
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `UPDATE transactions SET status = ? WHERE id = ?`,
     [status, id]
   );
@@ -408,7 +440,7 @@ export async function rekeyTransaction(
   oldId: string,
   posted: PlaidTransaction
 ): Promise<RekeyResult> {
-  const d = db();
+  const d = await dbReady();
   let result: RekeyResult = 'not_found';
   await d.withTransactionAsync(async () => {
     const row = await d.getFirstAsync<{ id: string; amount: number; status: TransactionStatus }>(
@@ -468,7 +500,7 @@ export async function rekeyTransaction(
 // Returns the ids that were kept, for logging/testing.
 export async function markTransactionsReversed(ids: string[]): Promise<string[]> {
   if (ids.length === 0) return [];
-  const d = db();
+  const d = await dbReady();
   const rows = await getTransactionsByIds(ids);
   const keepIds = rows.filter((r) => r.status === 'split').map((r) => r.id);
   const keepSet = new Set(keepIds);
@@ -489,7 +521,7 @@ export async function markTransactionsReversed(ids: string[]): Promise<string[]>
 }
 
 export async function getSplitDecision(transactionId: string): Promise<SplitDecision | null> {
-  const row = await db().getFirstAsync<{
+  const row = await (await dbReady()).getFirstAsync<{
     id: string;
     transaction_id: string;
     splitwise_expense_id: string;
@@ -514,7 +546,7 @@ export async function getSplitDecision(transactionId: string): Promise<SplitDeci
 export async function insertSplitDecision(
   decision: SplitDecision
 ): Promise<void> {
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `INSERT INTO split_decisions (id, transaction_id, splitwise_expense_id, friend_ids, friend_names, amount_each, created_at, description)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     [
@@ -531,7 +563,7 @@ export async function insertSplitDecision(
 }
 
 export async function upsertSplitDecision(decision: SplitDecision): Promise<void> {
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `INSERT INTO split_decisions (id, transaction_id, splitwise_expense_id, friend_ids, friend_names, amount_each, created_at, description)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(transaction_id) DO UPDATE SET
@@ -554,7 +586,7 @@ export async function upsertSplitDecision(decision: SplitDecision): Promise<void
 }
 
 export async function deleteSplitDecision(transactionId: string): Promise<void> {
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `DELETE FROM split_decisions WHERE transaction_id = ?`,
     [transactionId]
   );
@@ -564,7 +596,7 @@ export async function deleteSplitDecision(transactionId: string): Promise<void> 
 // 'split'. Wrapped in a single SQLite transaction so a mid-batch failure rolls
 // back the whole combined split locally (no half-written members).
 export async function persistCombinedSplit(decisions: SplitDecision[]): Promise<void> {
-  await db().withTransactionAsync(async () => {
+  await (await dbReady()).withTransactionAsync(async () => {
     for (const d of decisions) {
       await insertSplitDecision(d);
       await updateTransactionStatus(d.transaction_id, 'split');
@@ -575,7 +607,7 @@ export async function persistCombinedSplit(decisions: SplitDecision[]): Promise<
 // Atomically delete every member's decision row and revert its transaction to
 // 'new'. Single transaction so a failure can't leave the group half-reverted.
 export async function revertCombinedSplit(transactionIds: string[]): Promise<void> {
-  await db().withTransactionAsync(async () => {
+  await (await dbReady()).withTransactionAsync(async () => {
     for (const id of transactionIds) {
       await deleteSplitDecision(id);
       await updateTransactionStatus(id, 'new');
@@ -584,14 +616,14 @@ export async function revertCombinedSplit(transactionIds: string[]): Promise<voi
 }
 
 export async function pruneOldTransactions(): Promise<void> {
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `DELETE FROM transactions WHERE created_at < datetime('now', '-6 months')`,
     []
   );
 }
 
 export async function deleteAllTransactions(): Promise<void> {
-  await db().runAsync(`DELETE FROM transactions`, []);
+  await (await dbReady()).runAsync(`DELETE FROM transactions`, []);
 }
 
 function mapVacationRow(row: {
@@ -608,7 +640,7 @@ function mapVacationRow(row: {
 }
 
 export async function createVacation(input: CreateVacationInput): Promise<Vacation> {
-  const d = db();
+  const d = await dbReady();
   if (input.start_date && input.end_date) {
     // Overlap = existing.start <= new.end AND new.start <= existing.end.
     const conflicts = await d.getAllAsync(
@@ -650,7 +682,7 @@ export async function createVacation(input: CreateVacationInput): Promise<Vacati
 }
 
 export async function getVacations(): Promise<Vacation[]> {
-  const rows = await db().getAllAsync<Parameters<typeof mapVacationRow>[0]>(
+  const rows = await (await dbReady()).getAllAsync<Parameters<typeof mapVacationRow>[0]>(
     `SELECT * FROM vacations
      ORDER BY CASE status WHEN 'ended' THEN 1 ELSE 0 END, COALESCE(start_date, created_at) DESC`,
     []
@@ -659,7 +691,7 @@ export async function getVacations(): Promise<Vacation[]> {
 }
 
 export async function getVacation(id: string): Promise<Vacation | null> {
-  const row = await db().getFirstAsync<Parameters<typeof mapVacationRow>[0]>(
+  const row = await (await dbReady()).getFirstAsync<Parameters<typeof mapVacationRow>[0]>(
     `SELECT * FROM vacations WHERE id = ?`,
     [id]
   );
@@ -667,7 +699,7 @@ export async function getVacation(id: string): Promise<Vacation | null> {
 }
 
 export async function getActiveVacation(): Promise<Vacation | null> {
-  const row = await db().getFirstAsync<Parameters<typeof mapVacationRow>[0]>(
+  const row = await (await dbReady()).getFirstAsync<Parameters<typeof mapVacationRow>[0]>(
     `SELECT * FROM vacations WHERE status = 'active'`,
     []
   );
@@ -675,21 +707,21 @@ export async function getActiveVacation(): Promise<Vacation | null> {
 }
 
 export async function startVacation(id: string): Promise<void> {
-  const others = await db().getAllAsync<{ id: string }>(
+  const others = await (await dbReady()).getAllAsync<{ id: string }>(
     `SELECT id FROM vacations WHERE status = 'active' AND id != ?`,
     [id]
   );
   if (others.length > 0) {
     throw new VacationConflictError('already_active', 'Another vacation is already active.');
   }
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `UPDATE vacations SET status = 'active', started_at = ? WHERE id = ?`,
     [new Date().toISOString(), id]
   );
 }
 
 export async function endVacation(id: string): Promise<void> {
-  await db().runAsync(
+  await (await dbReady()).runAsync(
     `UPDATE vacations SET status = 'ended', ended_at = ? WHERE id = ?`,
     [new Date().toISOString(), id]
   );
@@ -700,7 +732,7 @@ export async function updateVacationDates(
   startDate: string | null,
   endDate: string | null
 ): Promise<void> {
-  const d = db();
+  const d = await dbReady();
   if (startDate && endDate) {
     // The same overlap rule createVacation applies, minus this vacation
     // itself — every trip overlaps its own dates.
@@ -723,11 +755,11 @@ export async function updateVacationDates(
 }
 
 export async function deleteVacation(id: string): Promise<void> {
-  await db().withTransactionAsync(async () => {
-    await db().runAsync(
+  await (await dbReady()).withTransactionAsync(async () => {
+    await (await dbReady()).runAsync(
       `UPDATE transactions SET vacation_id = NULL WHERE vacation_id = ? AND status = 'new'`,
       [id]
     );
-    await db().runAsync(`DELETE FROM vacations WHERE id = ?`, [id]);
+    await (await dbReady()).runAsync(`DELETE FROM vacations WHERE id = ?`, [id]);
   });
 }

--- a/mobile/lib/db.web.ts
+++ b/mobile/lib/db.web.ts
@@ -17,6 +17,7 @@ const DECISION_STORE = 'split_decisions';
 const VACATION_STORE = 'vacations';
 
 let _db: IDBDatabase | null = null;
+let _opening: Promise<IDBDatabase> | null = null;
 
 function req<T>(r: IDBRequest<T>): Promise<T> {
   return new Promise((resolve, reject) => {
@@ -36,13 +37,42 @@ function done(tx: IDBTransaction): Promise<void> {
   });
 }
 
-function db(): IDBDatabase {
-  if (!_db) throw new Error('DB not initialized — call initDb() first');
+/**
+ * The open database, opening it on first use.
+ *
+ * Callers must not have to sequence themselves behind initDb(). React runs
+ * effects child-first, so a route's mount effect queries the database *before*
+ * the root layout's effect has had a chance to open it — the module owns its
+ * own readiness instead. Concurrent callers share one in-flight open.
+ */
+async function dbReady(): Promise<IDBDatabase> {
+  if (_db) return _db;
+  if (!_opening) {
+    // Cleared on failure so a later call can retry rather than replaying a
+    // rejected promise forever.
+    _opening = openDatabase().catch((e) => {
+      _opening = null;
+      throw e;
+    });
+  }
+  _db = await _opening;
   return _db;
 }
 
+/** Opens (and migrates) the database. Idempotent — safe to call repeatedly. */
 export async function initDb(): Promise<void> {
-  _db = await new Promise<IDBDatabase>((resolve, reject) => {
+  await dbReady();
+}
+
+/** Drops the cached handle so the next call reopens. Tests only. */
+export function resetDbForTests(): void {
+  _db?.close();
+  _db = null;
+  _opening = null;
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise<IDBDatabase>((resolve, reject) => {
     const open = indexedDB.open(DB_NAME, DB_VERSION);
     open.onupgradeneeded = () => {
       const d = open.result;
@@ -77,13 +107,13 @@ function byDateDesc(a: Transaction, b: Transaction): number {
 }
 
 export async function getNewTransactions(): Promise<Transaction[]> {
-  const all = await req(db().transaction(TX_STORE).objectStore(TX_STORE).getAll() as IDBRequest<Transaction[]>);
+  const all = await req((await dbReady()).transaction(TX_STORE).objectStore(TX_STORE).getAll() as IDBRequest<Transaction[]>);
   return all.filter((t) => t.status === 'new' && !t.vacation_id).sort(byDateDesc);
 }
 
 export async function getTransactionsByIds(ids: string[]): Promise<Transaction[]> {
   if (ids.length === 0) return [];
-  const store = db().transaction(TX_STORE).objectStore(TX_STORE);
+  const store = (await dbReady()).transaction(TX_STORE).objectStore(TX_STORE);
   const rows = await Promise.all(
     ids.map((id) => req(store.get(id) as IDBRequest<Transaction | undefined>)),
   );
@@ -145,7 +175,7 @@ function groupHistoryRows(rows: Transaction[], decisions: SplitDecision[]): Hist
 }
 
 export async function getHistoryTransactions(): Promise<HistoryItem[]> {
-  const tx = db().transaction([TX_STORE, DECISION_STORE]);
+  const tx = (await dbReady()).transaction([TX_STORE, DECISION_STORE]);
   const [all, decisions] = await Promise.all([
     req(tx.objectStore(TX_STORE).getAll() as IDBRequest<Transaction[]>),
     req(tx.objectStore(DECISION_STORE).getAll() as IDBRequest<SplitDecision[]>),
@@ -205,7 +235,7 @@ function groupReviewRows(rows: Transaction[], decisions: SplitDecision[]): Revie
 }
 
 export async function getReviewTransactions(): Promise<ReviewItem[]> {
-  const tx = db().transaction([TX_STORE, DECISION_STORE]);
+  const tx = (await dbReady()).transaction([TX_STORE, DECISION_STORE]);
   const [all, decisions] = await Promise.all([
     req(tx.objectStore(TX_STORE).getAll() as IDBRequest<Transaction[]>),
     req(tx.objectStore(DECISION_STORE).getAll() as IDBRequest<SplitDecision[]>),
@@ -216,7 +246,7 @@ export async function getReviewTransactions(): Promise<ReviewItem[]> {
 
 export async function clearReview(transactionIds: string[]): Promise<void> {
   if (transactionIds.length === 0) return;
-  const tx = db().transaction(TX_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(TX_STORE, 'readwrite');
   const store = tx.objectStore(TX_STORE);
   for (const id of transactionIds) {
     const existing = await req(store.get(id) as IDBRequest<Transaction | undefined>);
@@ -226,12 +256,12 @@ export async function clearReview(transactionIds: string[]): Promise<void> {
 }
 
 export async function getVacationPendingTransactions(vacationId: string): Promise<Transaction[]> {
-  const all = await req(db().transaction(TX_STORE).objectStore(TX_STORE).getAll() as IDBRequest<Transaction[]>);
+  const all = await req((await dbReady()).transaction(TX_STORE).objectStore(TX_STORE).getAll() as IDBRequest<Transaction[]>);
   return all.filter((t) => t.status === 'new' && t.vacation_id === vacationId).sort(byDateDesc);
 }
 
 export async function getVacationHistory(vacationId: string): Promise<HistoryItem[]> {
-  const tx = db().transaction([TX_STORE, DECISION_STORE]);
+  const tx = (await dbReady()).transaction([TX_STORE, DECISION_STORE]);
   const [all, decisions] = await Promise.all([
     req(tx.objectStore(TX_STORE).getAll() as IDBRequest<Transaction[]>),
     req(tx.objectStore(DECISION_STORE).getAll() as IDBRequest<SplitDecision[]>),
@@ -244,7 +274,7 @@ export async function getVacationHistory(vacationId: string): Promise<HistoryIte
 
 export async function assignTransactionsToVacation(vacationId: string, transactionIds: string[]): Promise<void> {
   if (transactionIds.length === 0) return;
-  const tx = db().transaction(TX_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(TX_STORE, 'readwrite');
   const store = tx.objectStore(TX_STORE);
   for (const id of transactionIds) {
     const existing = await req(store.get(id) as IDBRequest<Transaction | undefined>);
@@ -256,7 +286,7 @@ export async function assignTransactionsToVacation(vacationId: string, transacti
 }
 
 export async function removeTransactionFromVacation(transactionId: string): Promise<void> {
-  const tx = db().transaction(TX_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(TX_STORE, 'readwrite');
   const store = tx.objectStore(TX_STORE);
   const existing = await req(store.get(transactionId) as IDBRequest<Transaction | undefined>);
   if (existing && existing.status === 'new') store.put({ ...existing, vacation_id: null });
@@ -269,7 +299,7 @@ export async function reconcileVacationStatuses(): Promise<void> {
   // instant and stays UTC.
   const today = todayLocal();
   const now = new Date().toISOString();
-  const tx = db().transaction(VACATION_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(VACATION_STORE, 'readwrite');
   const store = tx.objectStore(VACATION_STORE);
   const all = await req(store.getAll() as IDBRequest<Vacation[]>);
 
@@ -319,7 +349,7 @@ export async function reconcileVacationStatuses(): Promise<void> {
 }
 
 export async function upsertTransactions(txs: PlaidTransaction[], activeVacationId: string | null = null): Promise<void> {
-  const tx = db().transaction(TX_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(TX_STORE, 'readwrite');
   const store = tx.objectStore(TX_STORE);
   const now = new Date().toISOString();
   // Invariant: only await IDB requests belonging to this txn inside the loop, so the txn stays active.
@@ -349,7 +379,7 @@ export async function upsertTransactions(txs: PlaidTransaction[], activeVacation
 
 export async function deleteTransactionsByPlaidIds(ids: string[]): Promise<void> {
   if (ids.length === 0) return;
-  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const tx = (await dbReady()).transaction([TX_STORE, DECISION_STORE], 'readwrite');
   for (const id of ids) {
     tx.objectStore(TX_STORE).delete(id);
     // SQLite cascades split_decisions via ON DELETE CASCADE; mirror that here.
@@ -359,7 +389,7 @@ export async function deleteTransactionsByPlaidIds(ids: string[]): Promise<void>
 }
 
 export async function updateTransactionStatus(id: string, status: TransactionStatus): Promise<void> {
-  const tx = db().transaction(TX_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(TX_STORE, 'readwrite');
   const store = tx.objectStore(TX_STORE);
   const existing = await req(store.get(id) as IDBRequest<Transaction | undefined>);
   if (existing) store.put({ ...existing, status });
@@ -374,7 +404,7 @@ export async function rekeyTransaction(
   oldId: string,
   posted: PlaidTransaction
 ): Promise<RekeyResult> {
-  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const tx = (await dbReady()).transaction([TX_STORE, DECISION_STORE], 'readwrite');
   const txStore = tx.objectStore(TX_STORE);
   const decStore = tx.objectStore(DECISION_STORE);
   // Invariant: only await IDB requests belonging to this txn, so it stays active.
@@ -428,7 +458,7 @@ export async function rekeyTransaction(
 // Mirrors lib/db.ts's markTransactionsReversed.
 export async function markTransactionsReversed(ids: string[]): Promise<string[]> {
   if (ids.length === 0) return [];
-  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const tx = (await dbReady()).transaction([TX_STORE, DECISION_STORE], 'readwrite');
   const txStore = tx.objectStore(TX_STORE);
   const decStore = tx.objectStore(DECISION_STORE);
   const kept: string[] = [];
@@ -449,13 +479,13 @@ export async function markTransactionsReversed(ids: string[]): Promise<string[]>
 
 export async function getSplitDecision(transactionId: string): Promise<SplitDecision | null> {
   const row = await req(
-    db().transaction(DECISION_STORE).objectStore(DECISION_STORE).get(transactionId) as IDBRequest<SplitDecision | undefined>,
+    (await dbReady()).transaction(DECISION_STORE).objectStore(DECISION_STORE).get(transactionId) as IDBRequest<SplitDecision | undefined>,
   );
   return row ?? null;
 }
 
 export async function insertSplitDecision(decision: SplitDecision): Promise<void> {
-  const tx = db().transaction(DECISION_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(DECISION_STORE, 'readwrite');
   // add() (not put) rejects on duplicate transaction_id, matching SQLite's
   // plain INSERT which throws on the UNIQUE(transaction_id) constraint.
   tx.objectStore(DECISION_STORE).add(decision);
@@ -463,13 +493,13 @@ export async function insertSplitDecision(decision: SplitDecision): Promise<void
 }
 
 export async function upsertSplitDecision(decision: SplitDecision): Promise<void> {
-  const tx = db().transaction(DECISION_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(DECISION_STORE, 'readwrite');
   tx.objectStore(DECISION_STORE).put(decision);
   await done(tx);
 }
 
 export async function deleteSplitDecision(transactionId: string): Promise<void> {
-  const tx = db().transaction(DECISION_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(DECISION_STORE, 'readwrite');
   tx.objectStore(DECISION_STORE).delete(transactionId);
   await done(tx);
 }
@@ -479,7 +509,7 @@ export async function deleteSplitDecision(transactionId: string): Promise<void> 
 // withTransactionAsync version: any failure aborts the whole group.
 export async function persistCombinedSplit(decisions: SplitDecision[]): Promise<void> {
   if (decisions.length === 0) return;
-  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const tx = (await dbReady()).transaction([TX_STORE, DECISION_STORE], 'readwrite');
   const txStore = tx.objectStore(TX_STORE);
   // Read every row up front, then issue all writes: a write that fails aborts
   // the txn, and a later get() on an aborting txn would reject with a less
@@ -501,7 +531,7 @@ export async function persistCombinedSplit(decisions: SplitDecision[]): Promise<
 // 'new'. Single transaction so a failure can't leave the group half-reverted.
 export async function revertCombinedSplit(transactionIds: string[]): Promise<void> {
   if (transactionIds.length === 0) return;
-  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const tx = (await dbReady()).transaction([TX_STORE, DECISION_STORE], 'readwrite');
   const txStore = tx.objectStore(TX_STORE);
   const rows = await Promise.all(
     transactionIds.map((id) => req(txStore.get(id) as IDBRequest<Transaction | undefined>)),
@@ -518,7 +548,7 @@ export async function pruneOldTransactions(): Promise<void> {
   const cutoff = new Date();
   cutoff.setMonth(cutoff.getMonth() - 6);
   const cutoffIso = cutoff.toISOString();
-  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const tx = (await dbReady()).transaction([TX_STORE, DECISION_STORE], 'readwrite');
   const store = tx.objectStore(TX_STORE);
   const all = await req(store.getAll() as IDBRequest<Transaction[]>);
   for (const t of all) {
@@ -531,7 +561,7 @@ export async function pruneOldTransactions(): Promise<void> {
 }
 
 export async function deleteAllTransactions(): Promise<void> {
-  const tx = db().transaction([TX_STORE, DECISION_STORE], 'readwrite');
+  const tx = (await dbReady()).transaction([TX_STORE, DECISION_STORE], 'readwrite');
   tx.objectStore(TX_STORE).clear();
   // Parity with SQLite ON DELETE CASCADE.
   tx.objectStore(DECISION_STORE).clear();
@@ -544,7 +574,7 @@ function rangesOverlap(aStart: string, aEnd: string, bStart: string, bEnd: strin
 
 export async function createVacation(input: CreateVacationInput): Promise<Vacation> {
   if (input.start_date && input.end_date) {
-    const all = await req(db().transaction(VACATION_STORE).objectStore(VACATION_STORE).getAll() as IDBRequest<Vacation[]>);
+    const all = await req((await dbReady()).transaction(VACATION_STORE).objectStore(VACATION_STORE).getAll() as IDBRequest<Vacation[]>);
     const conflict = all.some(
       (v) =>
         (v.status === 'draft' || v.status === 'active') &&
@@ -566,7 +596,7 @@ export async function createVacation(input: CreateVacationInput): Promise<Vacati
     started_at: null,
     ended_at: null,
   };
-  const tx = db().transaction(VACATION_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(VACATION_STORE, 'readwrite');
   tx.objectStore(VACATION_STORE).add(vacation);
   await done(tx);
   return vacation;
@@ -582,12 +612,12 @@ function byVacationOrder(a: Vacation, b: Vacation): number {
 }
 
 export async function getVacations(): Promise<Vacation[]> {
-  const all = await req(db().transaction(VACATION_STORE).objectStore(VACATION_STORE).getAll() as IDBRequest<Vacation[]>);
+  const all = await req((await dbReady()).transaction(VACATION_STORE).objectStore(VACATION_STORE).getAll() as IDBRequest<Vacation[]>);
   return all.sort(byVacationOrder);
 }
 
 export async function getVacation(id: string): Promise<Vacation | null> {
-  const row = await req(db().transaction(VACATION_STORE).objectStore(VACATION_STORE).get(id) as IDBRequest<Vacation | undefined>);
+  const row = await req((await dbReady()).transaction(VACATION_STORE).objectStore(VACATION_STORE).get(id) as IDBRequest<Vacation | undefined>);
   return row ?? null;
 }
 
@@ -601,7 +631,7 @@ export async function startVacation(id: string): Promise<void> {
   if (all.some((v) => v.status === 'active' && v.id !== id)) {
     throw new VacationConflictError('already_active', 'Another vacation is already active.');
   }
-  const tx = db().transaction(VACATION_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(VACATION_STORE, 'readwrite');
   const store = tx.objectStore(VACATION_STORE);
   const existing = await req(store.get(id) as IDBRequest<Vacation | undefined>);
   if (existing) store.put({ ...existing, status: 'active' as VacationStatus, started_at: new Date().toISOString() });
@@ -609,7 +639,7 @@ export async function startVacation(id: string): Promise<void> {
 }
 
 export async function endVacation(id: string): Promise<void> {
-  const tx = db().transaction(VACATION_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(VACATION_STORE, 'readwrite');
   const store = tx.objectStore(VACATION_STORE);
   const existing = await req(store.get(id) as IDBRequest<Vacation | undefined>);
   if (existing) store.put({ ...existing, status: 'ended' as VacationStatus, ended_at: new Date().toISOString() });
@@ -634,7 +664,7 @@ export async function updateVacationDates(
     );
     if (conflict) throw new VacationConflictError('overlap', 'Dates overlap an existing vacation.');
   }
-  const tx = db().transaction(VACATION_STORE, 'readwrite');
+  const tx = (await dbReady()).transaction(VACATION_STORE, 'readwrite');
   const store = tx.objectStore(VACATION_STORE);
   const existing = await req(store.get(id) as IDBRequest<Vacation | undefined>);
   if (existing) store.put({ ...existing, start_date: startDate, end_date: endDate });
@@ -642,7 +672,7 @@ export async function updateVacationDates(
 }
 
 export async function deleteVacation(id: string): Promise<void> {
-  const tx = db().transaction([TX_STORE, VACATION_STORE], 'readwrite');
+  const tx = (await dbReady()).transaction([TX_STORE, VACATION_STORE], 'readwrite');
   const txStore = tx.objectStore(TX_STORE);
   const all = await req(txStore.getAll() as IDBRequest<Transaction[]>);
   for (const t of all) {


### PR DESCRIPTION
**Hotfix for #67, which broke the app.** `main` is currently blank on every route; this restores it.

## What I broke

#67 deferred `<Slot />` until the database opened. That meant expo-router never registered the root navigator, so `index.tsx`'s first `router.replace()` threw:

```
Attempted to navigate before mounting the Root Layout component.
Ensure the Root Layout component is rendering a Slot, or other navigator on the first render.
    at app/index.tsx:30
```

`Slot` **must** render on the very first render. That's a hard expo-router requirement, and no conditional rendering in the root layout can satisfy it.

## Why my checks didn't catch it

Worth stating plainly, because both gaps were avoidable:

- The root-layout test **mocked `Slot` outright**, so there was no mounting constraint left to violate. The test could only ever pass.
- The browser check only exercised `/vacation` deep links — the routes that **never call `router.replace()`**. I verified the case the fix targeted and skipped the app's primary entry path.

## The actual fix

Rendering was never the right layer. React runs effects **child-first**, so a route's mount effect queries the database before the root layout's effect can open it — regardless of what the layout renders. Gating the tree only ever papered over that.

So `lib/db` now owns its own readiness. `db()` becomes an async `dbReady()` that opens on first use:

- Any caller at any time awaits the open instead of throwing `DB not initialized`
- Concurrent first callers share **one** in-flight open
- A failed open is cleared so a later call retries, rather than replaying a rejected promise forever
- On native the handle stays local until every migration has run, so a concurrent caller can't be handed a half-migrated database

`initDb()` stays as an idempotent warm-up the root layout still calls; `resetDbForTests()` lets suites drop the handle when they swap the IndexedDB factory.

## Tests that would have caught this

Both verified red against the broken code:

```
✕ Slot renders on the first render, before the database has opened
✕ Slot still renders when the database fails to open
```

The root-layout test now counts renders and asserts `Slot` was reached on render #1 — the constraint itself, not a mock of it. And the database tests cover a query issued with **no prior `initDb()` at all**, which is the real failure mode:

```
✕ a query with no prior initDb() opens the database instead of throwing
✕ concurrent first callers share a single open
✕ a failed open is retried rather than cached forever
```

## Verification

In the PWA, both paths this time:

- `/` renders and redirects to sign-in ✅ (the path #67 broke)
- cold load of `/vacation/<id>` renders the vacation ✅ (the path #67 fixed)
- console clean on both — only pre-existing RN-web deprecation warnings

`npx tsc --noEmit` clean; **289 tests across 29 suites** pass.

## Note

`StartupScreen` (extracted in #67) stays — `index.tsx` uses it, and its behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4yNBGWGvDeJhEj2V4N1j1